### PR TITLE
fix : 로그아웃 버그 해결

### DIFF
--- a/auth-service/src/main/java/com/samnammae/auth_service/domain/token/RefreshToken.java
+++ b/auth-service/src/main/java/com/samnammae/auth_service/domain/token/RefreshToken.java
@@ -17,7 +17,7 @@ public class RefreshToken {
     private Long id;
 
     // 유저의 PK (User 엔터티의 id)
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private Long userId;
 
     @Column(nullable = false, unique = true)

--- a/auth-service/src/main/java/com/samnammae/auth_service/domain/token/RefreshTokenRepository.java
+++ b/auth-service/src/main/java/com/samnammae/auth_service/domain/token/RefreshTokenRepository.java
@@ -2,16 +2,20 @@ package com.samnammae.auth_service.domain.token;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
-    // 유저 id로 토큰 조회
-    Optional<RefreshToken> findByUserId(Long userId);
+    // 유저 id로 모든 토큰 조회
+    List<RefreshToken> findAllByUserId(Long userId);
 
     // 토큰 string 으로 토큰 조회
     Optional<RefreshToken> findByToken(String token);
 
-    // 유저 id로 토큰 삭제
-    void deleteByUserId(Long userId);
+    // 유저 id와 토큰 string 으로 토큰 조회
+    Optional<RefreshToken> findByUserIdAndToken(Long userId, String token);
+
+    // userId + token 조합으로 삭제
+    void deleteByUserIdAndToken(Long userId, String token);
 }

--- a/auth-service/src/test/java/com/samnammae/auth_service/domain/token/RefreshTokenRepositoryTest.java
+++ b/auth-service/src/test/java/com/samnammae/auth_service/domain/token/RefreshTokenRepositoryTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,23 +20,29 @@ class RefreshTokenRepositoryTest {
     private RefreshTokenRepository refreshTokenRepository;
 
     @Test
-    @DisplayName("userId로 리프레시 토큰 조회 테스트")
-    void findByUserId() {
+    @DisplayName("userId로 리프레시 토큰 전체 조회 테스트")
+    void findAllByUserId() {
         // given
-        RefreshToken token = RefreshToken.builder()
+        refreshTokenRepository.save(RefreshToken.builder()
                 .userId(1L)
-                .token("refresh-token-123")
+                .token("refresh-token-1")
                 .expiresAt(LocalDateTime.now().plusDays(7))
                 .createdAt(LocalDateTime.now())
-                .build();
-        refreshTokenRepository.save(token);
+                .build());
+
+        refreshTokenRepository.save(RefreshToken.builder()
+                .userId(1L)
+                .token("refresh-token-2")
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .createdAt(LocalDateTime.now())
+                .build());
 
         // when
-        Optional<RefreshToken> result = refreshTokenRepository.findByUserId(1L);
+        List<RefreshToken> tokens = refreshTokenRepository.findAllByUserId(1L);
 
         // then
-        assertThat(result).isPresent();
-        assertThat(result.get().getToken()).isEqualTo("refresh-token-123");
+        assertThat(tokens).hasSize(2);
+        assertThat(tokens).extracting("token").contains("refresh-token-1", "refresh-token-2");
     }
 
     @Test
@@ -59,22 +66,49 @@ class RefreshTokenRepositoryTest {
     }
 
     @Test
-    @DisplayName("userId로 리프레시 토큰 삭제 테스트")
-    void deleteByUserId() {
+    @DisplayName("userId와 token으로 리프레시 토큰 조회 테스트")
+    void findByUserIdAndToken() {
         // given
+        Long userId = 4L;
+        String tokenStr = "refresh-token-999";
+
         RefreshToken token = RefreshToken.builder()
-                .userId(3L)
-                .token("refresh-token-789")
+                .userId(userId)
+                .token(tokenStr)
                 .expiresAt(LocalDateTime.now().plusDays(7))
                 .createdAt(LocalDateTime.now())
                 .build();
         refreshTokenRepository.save(token);
 
         // when
-        refreshTokenRepository.deleteByUserId(3L);
+        Optional<RefreshToken> result = refreshTokenRepository.findByUserIdAndToken(userId, tokenStr);
 
         // then
-        Optional<RefreshToken> result = refreshTokenRepository.findByUserId(3L);
+        assertThat(result).isPresent();
+        assertThat(result.get().getUserId()).isEqualTo(userId);
+        assertThat(result.get().getToken()).isEqualTo(tokenStr);
+    }
+
+    @Test
+    @DisplayName("userId와 token으로 리프레시 토큰 삭제 테스트")
+    void deleteByUserIdAndToken() {
+        // given
+        String tokenStr = "refresh-token-789";
+        Long userId = 3L;
+
+        refreshTokenRepository.save(RefreshToken.builder()
+                .userId(userId)
+                .token(tokenStr)
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        // when
+        refreshTokenRepository.deleteByUserIdAndToken(userId, tokenStr);
+
+        // then
+        Optional<RefreshToken> result = refreshTokenRepository.findByUserIdAndToken(userId, tokenStr);
         assertThat(result).isNotPresent();
     }
+
 }

--- a/auth-service/src/test/java/com/samnammae/auth_service/service/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/samnammae/auth_service/service/AuthServiceTest.java
@@ -98,7 +98,7 @@ class AuthServiceTest {
         given(jwtUtil.getRefreshTokenValidityInMs()).willReturn(refreshValidityMs);
         given(jwtUtil.generateAccessToken(eq(user), any(Date.class), any(Date.class))).willReturn(accessToken);
         given(jwtUtil.generateRefreshToken(eq(user), any(Date.class), any(Date.class))).willReturn(refreshToken);
-        given(refreshTokenRepository.findByUserId(user.getId())).willReturn(Optional.empty());
+        given(refreshTokenRepository.findByUserIdAndToken(user.getId(), refreshToken)).willReturn(Optional.empty());
 
         // when
         LoginResponse response = authService.login(request);
@@ -141,7 +141,7 @@ class AuthServiceTest {
         given(jwtUtil.getRefreshTokenValidityInMs()).willReturn(refreshValidityMs);
         given(jwtUtil.generateAccessToken(eq(user), any(Date.class), any(Date.class))).willReturn(accessToken);
         given(jwtUtil.generateRefreshToken(eq(user), any(Date.class), any(Date.class))).willReturn(refreshToken);
-        given(refreshTokenRepository.findByUserId(user.getId())).willReturn(Optional.of(existingToken));
+        given(refreshTokenRepository.findByUserIdAndToken(user.getId(), refreshToken)).willReturn(Optional.of(existingToken));
 
         // when
         LoginResponse response = authService.login(request);


### PR DESCRIPTION
## 🐞 주요 변경 사항
- 로그아웃 시 정상적으로 리프레쉬 토큰이 삭제되지 않던 버그 수정
- userId에 걸려 있던 `@Column(unique = true)` 제거 → 동일 사용자 다중 토큰 허용
- RefreshTokenRepository에서 userId 기준이던 삭제 로직을 userId와 token 기준으로 변경
- AuthService.login() 기존 토큰 업데이트 로직 수정
- 기존 테스트 코드 수정
<br>

## 🔗 관련 이슈
Closes #9