### PR TITLE
feat : 매장 등록 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,9 @@
 ### VS Code ###
 .vscode/
 
+### Build output ###
+build/
+
 application-secret.yml
+
+/uploads

--- a/admin-service/build.gradle
+++ b/admin-service/build.gradle
@@ -24,15 +24,30 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// Spring
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// DB
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// 개발 편의
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+	// 테스트
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// 스웨거
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	implementation project(':common-module')
 }
 
 tasks.named('test') {

--- a/admin-service/src/main/java/com/samnammae/admin_service/config/OpenApiConfig.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/config/OpenApiConfig.java
@@ -1,0 +1,25 @@
+package com.samnammae.admin_service.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList("Authorization"))
+                .components(new Components()
+                        .addSecuritySchemes("Authorization", new SecurityScheme()
+                                .name("Authorization")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)));
+    }
+}

--- a/admin-service/src/main/java/com/samnammae/admin_service/config/WebConfig.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.samnammae.admin_service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 API 경로에 대해
+                .allowedOrigins("http://inclukiosk-fe.s3-website.ap-northeast-2.amazonaws.com",
+                        "http://localhost:5173",
+                        "http://localhost:3000") // 허용할 프론트 주소
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/admin-service/src/main/java/com/samnammae/admin_service/controller/StoreController.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/controller/StoreController.java
@@ -1,0 +1,28 @@
+package com.samnammae.admin_service.controller;
+
+import com.samnammae.admin_service.dto.request.StoreRequest;
+import com.samnammae.admin_service.service.StoreService;
+import com.samnammae.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartException;
+
+@RestController
+@RequestMapping("/api/admin/store")
+@Tag(name = "Admin", description = "관리자 관련 API")
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @PostMapping(consumes = "multipart/form-data")
+    public ApiResponse<Long> registerStore(@ModelAttribute StoreRequest request) {
+        Long storeId = storeService.createStore(request);
+        return ApiResponse.success(storeId);
+    }
+}

--- a/admin-service/src/main/java/com/samnammae/admin_service/controller/StoreController.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/controller/StoreController.java
@@ -3,14 +3,17 @@ package com.samnammae.admin_service.controller;
 import com.samnammae.admin_service.dto.request.StoreRequest;
 import com.samnammae.admin_service.service.StoreService;
 import com.samnammae.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartException;
 
 @RestController
 @RequestMapping("/api/admin/store")
@@ -20,8 +23,17 @@ public class StoreController {
 
     private final StoreService storeService;
 
-    @PostMapping(consumes = "multipart/form-data")
-    public ApiResponse<Long> registerStore(@ModelAttribute StoreRequest request) {
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "매장 등록", description = "매장 정보를 입력하여 새로운 매장을 등록합니다.")
+    public ApiResponse<Long> registerStore(
+            @RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(implementation = StoreRequest.class)
+                    )
+            )
+            @ModelAttribute StoreRequest request) {
         Long storeId = storeService.createStore(request);
         return ApiResponse.success(storeId);
     }

--- a/admin-service/src/main/java/com/samnammae/admin_service/controller/StoreController.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/controller/StoreController.java
@@ -4,16 +4,14 @@ import com.samnammae.admin_service.dto.request.StoreRequest;
 import com.samnammae.admin_service.service.StoreService;
 import com.samnammae.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/admin/store")
@@ -26,14 +24,14 @@ public class StoreController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "매장 등록", description = "매장 정보를 입력하여 새로운 매장을 등록합니다.")
     public ApiResponse<Long> registerStore(
-            @RequestBody(
-                    required = true,
-                    content = @Content(
-                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                            schema = @Schema(implementation = StoreRequest.class)
-                    )
-            )
-            @ModelAttribute StoreRequest request) {
+            @RequestPart("request") StoreRequest request,
+            @RequestPart(value = "mainImg", required = false) MultipartFile mainImg,
+            @RequestPart(value = "logoImg", required = false) MultipartFile logoImg,
+            @RequestPart(value = "startBackground", required = false) MultipartFile startBackground
+    ) {
+        request.setMainImg(mainImg);
+        request.setLogoImg(logoImg);
+        request.setStartBackground(startBackground);
         Long storeId = storeService.createStore(request);
         return ApiResponse.success(storeId);
     }

--- a/admin-service/src/main/java/com/samnammae/admin_service/domain/store/Store.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/domain/store/Store.java
@@ -1,0 +1,42 @@
+package com.samnammae.admin_service.domain.store;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "store")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;         // 매장 이름
+
+    @Column(nullable = false)
+    private String phone;        // 매장 전화번호
+
+    @Column(nullable = false)
+    private String address;      // 매장 주소
+
+    @Column(columnDefinition = "TEXT")
+    private String introduction; // 매장 소개 (선택)
+
+    private String mainImgUrl;   // 메인 이미지 URL (선택)
+    private String logoImgUrl;   // 로고 이미지 URL (선택)
+    private String startBackgroundUrl; // 시작 배경 이미지 URL (선택)
+
+    @Column(nullable = false)
+    private String mainColor;    // 메인 컬러 (#002F6C 등)
+
+    @Column(nullable = false)
+    private String subColor;     // 서브 컬러 (#0051A3 등)
+
+    @Column(nullable = false)
+    private String textColor;    // 텍스트 컬러 (#F8F9FA 등)
+}

--- a/admin-service/src/main/java/com/samnammae/admin_service/domain/store/StoreRepository.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/domain/store/StoreRepository.java
@@ -1,0 +1,6 @@
+package com.samnammae.admin_service.domain.store;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/admin-service/src/main/java/com/samnammae/admin_service/domain/store/StoreRepository.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/domain/store/StoreRepository.java
@@ -1,6 +1,8 @@
 package com.samnammae.admin_service.domain.store;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StoreRepository extends JpaRepository<Store, Long> {
 }

--- a/admin-service/src/main/java/com/samnammae/admin_service/dto/request/StoreRequest.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/dto/request/StoreRequest.java
@@ -1,5 +1,6 @@
 package com.samnammae.admin_service.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,8 +19,11 @@ public class StoreRequest {
     private String address;
     private String introduction;
 
+    @Schema(type = "string", format = "binary")
     private MultipartFile mainImg;
+    @Schema(type = "string", format = "binary")
     private MultipartFile logoImg;
+    @Schema(type = "string", format = "binary")
     private MultipartFile startBackground;
 
     private String mainColor;

--- a/admin-service/src/main/java/com/samnammae/admin_service/dto/request/StoreRequest.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/dto/request/StoreRequest.java
@@ -1,10 +1,7 @@
 package com.samnammae.admin_service.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
 
@@ -12,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class StoreRequest {
 
     private String name;

--- a/admin-service/src/main/java/com/samnammae/admin_service/dto/request/StoreRequest.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/dto/request/StoreRequest.java
@@ -1,0 +1,28 @@
+package com.samnammae.admin_service.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreRequest {
+
+    private String name;
+    private String phone;
+    private String address;
+    private String introduction;
+
+    private MultipartFile mainImg;
+    private MultipartFile logoImg;
+    private MultipartFile startBackground;
+
+    private String mainColor;
+    private String subColor;
+    private String textColor;
+}

--- a/admin-service/src/main/java/com/samnammae/admin_service/exception/GlobalExceptionHandler.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.samnammae.admin_service.exception;
+
+import com.samnammae.common.exception.CustomException;
+import com.samnammae.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Hidden
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ApiResponse.error(
+                        e.getErrorCode().getStatus(),
+                        e.getErrorCode().getMessage()
+                ));
+    }
+}

--- a/admin-service/src/main/java/com/samnammae/admin_service/service/FileStorageService.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/service/FileStorageService.java
@@ -1,0 +1,7 @@
+package com.samnammae.admin_service.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileStorageService {
+    String upload(MultipartFile file);
+}

--- a/admin-service/src/main/java/com/samnammae/admin_service/service/StoreService.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/service/StoreService.java
@@ -1,0 +1,56 @@
+package com.samnammae.admin_service.service;
+
+import com.samnammae.admin_service.domain.store.Store;
+import com.samnammae.admin_service.domain.store.StoreRepository;
+import com.samnammae.admin_service.dto.request.StoreRequest;
+import com.samnammae.common.exception.CustomException;
+import com.samnammae.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+    private final FileStorageService fileStorageService;
+
+    // 가게 등록
+    public Long createStore(StoreRequest request) {
+        String mainImgUrl = uploadFile(request.getMainImg());
+        String logoImgUrl = uploadFile(request.getLogoImg());
+        String backgroundUrl = uploadFile(request.getStartBackground());
+
+        Store store = Store.builder()
+                .name(request.getName())
+                .phone(request.getPhone())
+                .address(request.getAddress())
+                .introduction(request.getIntroduction())
+                .mainImgUrl(mainImgUrl)
+                .logoImgUrl(logoImgUrl)
+                .startBackgroundUrl(backgroundUrl)
+                .mainColor(request.getMainColor())
+                .subColor(request.getSubColor())
+                .textColor(request.getTextColor())
+                .build();
+
+        return storeRepository.save(store).getId();
+    }
+
+    // 이미지 파일 업로드
+    private String uploadFile(MultipartFile file) {
+        // 파일이 비어있거나 null인 경우 예외 처리
+        if (file == null || file.isEmpty()) {
+            return null;
+        }
+
+        // 파일 업로드 서비스 호출
+        try {
+            return fileStorageService.upload(file);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+}

--- a/admin-service/src/main/java/com/samnammae/admin_service/service/impl/LocalFileStorageService.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/service/impl/LocalFileStorageService.java
@@ -1,0 +1,47 @@
+package com.samnammae.admin_service.service.impl;
+
+import com.samnammae.admin_service.service.FileStorageService;
+import com.samnammae.common.exception.CustomException;
+import com.samnammae.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@Qualifier("localFileStorage")
+public class LocalFileStorageService implements FileStorageService {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    public String upload(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        String extension = getExtension(originalFilename);
+        String savedFileName = UUID.randomUUID() + extension;
+
+        File targetFile = new File(uploadDir, savedFileName);
+
+        try {
+            file.transferTo(targetFile);
+            log.info("파일 저장 완료: {}", targetFile.getAbsolutePath());
+            return "/files/" + savedFileName; // 정적 리소스로 접근 가능하게 리턴 경로 설정
+        } catch (IOException e) {
+            log.error("파일 저장 실패", e);
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    private String getExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf("."));
+    }
+}

--- a/admin-service/src/main/resources/application-test.yml
+++ b/admin-service/src/main/resources/application-test.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop  # 테스트 시 테이블 자동 생성 및 삭제
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true           # SQL 로그 출력
+    properties:
+      hibernate:
+        format_sql: true     # SQL 로그 포맷팅

--- a/admin-service/src/main/resources/application.yml
+++ b/admin-service/src/main/resources/application.yml
@@ -9,7 +9,7 @@ springdoc:
       enabled: false  # 스웨거 UI 테스트시 csrf 끄기
 
 file:
-  upload-dir: ./uploads
+  upload-dir: ${user.dir}/uploads
 
 spring:
   config:

--- a/admin-service/src/main/resources/application.yml
+++ b/admin-service/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+    csrf:
+      enabled: false  # 스웨거 UI 테스트시 csrf 끄기
+
+file:
+  upload-dir: ./uploads
+
+spring:
+  config:
+    import: optional:classpath:application-secret.yml
+
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect

--- a/admin-service/src/test/java/com/samnammae/admin_service/config/TestConfig.java
+++ b/admin-service/src/test/java/com/samnammae/admin_service/config/TestConfig.java
@@ -1,0 +1,14 @@
+package com.samnammae.admin_service.config;
+
+import com.samnammae.admin_service.service.StoreService;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+    @Bean
+    public StoreService storeService() {
+        return Mockito.mock(StoreService.class);
+    }
+}

--- a/admin-service/src/test/java/com/samnammae/admin_service/controller/StoreControllerTest.java
+++ b/admin-service/src/test/java/com/samnammae/admin_service/controller/StoreControllerTest.java
@@ -38,6 +38,18 @@ class StoreControllerTest {
     @DisplayName("매장 등록 성공 테스트")
     void registerStore_success() throws Exception {
         // given
+        StoreRequest storeRequest = StoreRequest.builder()
+                .name("테스트매장")
+                .phone("010-1234-5678")
+                .address("서울시 어딘가")
+                .introduction("테스트 소개")
+                .mainColor("#002F6C")
+                .subColor("#0051A3")
+                .textColor("#F8F9FA")
+                .build();
+        byte[] jsonBytes = objectMapper.writeValueAsBytes(storeRequest);
+
+        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json", jsonBytes);
         MockMultipartFile mainImg = new MockMultipartFile("mainImg", "main.jpg", "image/jpeg", "image-content".getBytes());
         MockMultipartFile logoImg = new MockMultipartFile("logoImg", "logo.jpg", "image/jpeg", "image-content".getBytes());
         MockMultipartFile background = new MockMultipartFile("startBackground", "bg.jpg", "image/jpeg", "image-content".getBytes());
@@ -46,16 +58,10 @@ class StoreControllerTest {
 
         // when and then
         mockMvc.perform(multipart("/api/admin/store")
+                        .file(requestPart)
                         .file(mainImg)
                         .file(logoImg)
                         .file(background)
-                        .param("name", "테스트매장")
-                        .param("phone", "010-1234-5678")
-                        .param("address", "서울시 어딘가")
-                        .param("introduction", "테스트 소개")
-                        .param("mainColor", "#002F6C")
-                        .param("subColor", "#0051A3")
-                        .param("textColor", "#F8F9FA")
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -66,6 +72,17 @@ class StoreControllerTest {
     @DisplayName("매장 등록 실패 테스트 - 파일 업로드 실패 예외 발생")
     void registerStore_fail_dueToFileUploadError() throws Exception {
         // given
+        StoreRequest storeRequest = StoreRequest.builder()
+                .name("테스트매장")
+                .phone("010-1234-5678")
+                .address("서울시 어딘가")
+                .mainColor("#002F6C")
+                .subColor("#0051A3")
+                .textColor("#F8F9FA")
+                .build();
+        byte[] jsonBytes = objectMapper.writeValueAsBytes(storeRequest);
+
+        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json", jsonBytes);
         MockMultipartFile mainImg = new MockMultipartFile("mainImg", "main.jpg", "image/jpeg", "image-content".getBytes());
 
         Mockito.when(storeService.createStore(any(StoreRequest.class)))
@@ -73,13 +90,8 @@ class StoreControllerTest {
 
         // when and then
         mockMvc.perform(multipart("/api/admin/store")
+                        .file(requestPart)
                         .file(mainImg)
-                        .param("name", "테스트매장")
-                        .param("phone", "010-1234-5678")
-                        .param("address", "서울시 어딘가")
-                        .param("mainColor", "#002F6C")
-                        .param("subColor", "#0051A3")
-                        .param("textColor", "#F8F9FA")
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().is5xxServerError())
                 .andExpect(jsonPath("$.success").value(false))

--- a/admin-service/src/test/java/com/samnammae/admin_service/controller/StoreControllerTest.java
+++ b/admin-service/src/test/java/com/samnammae/admin_service/controller/StoreControllerTest.java
@@ -1,0 +1,89 @@
+package com.samnammae.admin_service.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.samnammae.admin_service.config.TestConfig;
+import com.samnammae.admin_service.dto.request.StoreRequest;
+import com.samnammae.admin_service.service.StoreService;
+import com.samnammae.common.exception.CustomException;
+import com.samnammae.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StoreController.class)
+@Import(TestConfig.class)  // 수동 빈 설정 클래스
+class StoreControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private StoreService storeService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("매장 등록 성공 테스트")
+    void registerStore_success() throws Exception {
+        // given
+        MockMultipartFile mainImg = new MockMultipartFile("mainImg", "main.jpg", "image/jpeg", "image-content".getBytes());
+        MockMultipartFile logoImg = new MockMultipartFile("logoImg", "logo.jpg", "image/jpeg", "image-content".getBytes());
+        MockMultipartFile background = new MockMultipartFile("startBackground", "bg.jpg", "image/jpeg", "image-content".getBytes());
+
+        Mockito.when(storeService.createStore(any(StoreRequest.class))).thenReturn(1L);
+
+        // when and then
+        mockMvc.perform(multipart("/api/admin/store")
+                        .file(mainImg)
+                        .file(logoImg)
+                        .file(background)
+                        .param("name", "테스트매장")
+                        .param("phone", "010-1234-5678")
+                        .param("address", "서울시 어딘가")
+                        .param("introduction", "테스트 소개")
+                        .param("mainColor", "#002F6C")
+                        .param("subColor", "#0051A3")
+                        .param("textColor", "#F8F9FA")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(1));
+    }
+
+    @Test
+    @DisplayName("매장 등록 실패 테스트 - 파일 업로드 실패 예외 발생")
+    void registerStore_fail_dueToFileUploadError() throws Exception {
+        // given
+        MockMultipartFile mainImg = new MockMultipartFile("mainImg", "main.jpg", "image/jpeg", "image-content".getBytes());
+
+        Mockito.when(storeService.createStore(any(StoreRequest.class)))
+                .thenThrow(new CustomException(ErrorCode.FILE_UPLOAD_FAILED));
+
+        // when and then
+        mockMvc.perform(multipart("/api/admin/store")
+                        .file(mainImg)
+                        .param("name", "테스트매장")
+                        .param("phone", "010-1234-5678")
+                        .param("address", "서울시 어딘가")
+                        .param("mainColor", "#002F6C")
+                        .param("subColor", "#0051A3")
+                        .param("textColor", "#F8F9FA")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().is5xxServerError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(500))
+                .andExpect(jsonPath("$.message").value("파일 업로드에 실패했습니다."));
+    }
+}

--- a/admin-service/src/test/java/com/samnammae/admin_service/service/StoreServiceTest.java
+++ b/admin-service/src/test/java/com/samnammae/admin_service/service/StoreServiceTest.java
@@ -1,0 +1,153 @@
+package com.samnammae.admin_service.service;
+
+import com.samnammae.admin_service.domain.store.Store;
+import com.samnammae.admin_service.domain.store.StoreRepository;
+import com.samnammae.admin_service.dto.request.StoreRequest;
+import com.samnammae.common.exception.CustomException;
+import com.samnammae.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+    @InjectMocks
+    private StoreService storeService;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private FileStorageService fileStorageService;
+
+    @Captor
+    private ArgumentCaptor<Store> storeCaptor;
+
+    @Test
+    @DisplayName("매장 등록 성공 테스트")
+    void createStore_success() {
+        // given
+        StoreRequest request = createStoreRequest();
+        String expectedFileUrl = "stored-file.jpg";
+
+        given(fileStorageService.upload(any())).willReturn(expectedFileUrl);
+
+        Store savedStore = mock(Store.class);
+        given(savedStore.getId()).willReturn(1L);
+        given(storeRepository.save(any())).willReturn(savedStore);
+
+        // when
+        Long storeId = storeService.createStore(request);
+
+        // then
+        assertThat(storeId).isEqualTo(1L);
+
+        // 파일 업로드 메소드가 3번 호출되었는지 확인
+        then(fileStorageService).should(times(3)).upload(any());
+
+        // 저장된 엔티티 내용 검증
+        verify(storeRepository).save(storeCaptor.capture());
+        Store capturedStore = storeCaptor.getValue();
+
+        assertThat(capturedStore.getName()).isEqualTo(request.getName());
+        assertThat(capturedStore.getPhone()).isEqualTo(request.getPhone());
+        assertThat(capturedStore.getAddress()).isEqualTo(request.getAddress());
+        assertThat(capturedStore.getIntroduction()).isEqualTo(request.getIntroduction());
+        assertThat(capturedStore.getMainImgUrl()).isEqualTo(expectedFileUrl);
+        assertThat(capturedStore.getLogoImgUrl()).isEqualTo(expectedFileUrl);
+        assertThat(capturedStore.getStartBackgroundUrl()).isEqualTo(expectedFileUrl);
+        assertThat(capturedStore.getMainColor()).isEqualTo(request.getMainColor());
+        assertThat(capturedStore.getSubColor()).isEqualTo(request.getSubColor());
+        assertThat(capturedStore.getTextColor()).isEqualTo(request.getTextColor());
+    }
+
+    @Test
+    @DisplayName("파일 업로드 중 예외 발생 시 FILE_UPLOAD_FAILED 예외 발생")
+    void createStore_uploadFail() {
+        // given
+        StoreRequest request = createStoreRequest();
+
+        given(fileStorageService.upload(any())).willThrow(new RuntimeException("업로드 실패"));
+
+        // when and then
+        assertThatThrownBy(() -> storeService.createStore(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    CustomException ce = (CustomException) e;
+                    assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.FILE_UPLOAD_FAILED);
+                });
+
+        // 저장소 메소드가 호출되지 않았는지 확인
+        then(storeRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("이미지 파일이 없을 경우에도 매장 등록 성공")
+    void createStore_withoutImages_success() {
+        // given
+        StoreRequest request = createStoreRequestWithoutImages();
+
+        Store savedStore = mock(Store.class);
+        given(savedStore.getId()).willReturn(1L);
+        given(storeRepository.save(any())).willReturn(savedStore);
+
+        // when
+        Long storeId = storeService.createStore(request);
+
+        // then
+        assertThat(storeId).isEqualTo(1L);
+
+        // 파일 업로드가 호출되지 않음
+        then(fileStorageService).shouldHaveNoInteractions();
+
+        // 저장된 엔티티 내용 검증
+        verify(storeRepository).save(storeCaptor.capture());
+        Store capturedStore = storeCaptor.getValue();
+
+        assertThat(capturedStore.getName()).isEqualTo(request.getName());
+        assertThat(capturedStore.getMainImgUrl()).isNull();
+        assertThat(capturedStore.getLogoImgUrl()).isNull();
+        assertThat(capturedStore.getStartBackgroundUrl()).isNull();
+    }
+
+    // 테스트에 사용할 요청 객체 생성 메소드
+    private StoreRequest createStoreRequest() {
+        StoreRequest request = new StoreRequest();
+        request.setName("테스트매장");
+        request.setPhone("010-1234-5678");
+        request.setAddress("서울시 어딘가");
+        request.setIntroduction("소개입니다.");
+        request.setMainColor("#002F6C");
+        request.setSubColor("#0051A3");
+        request.setTextColor("#F8F9FA");
+        request.setMainImg(new MockMultipartFile("mainImg", "main.jpg", "image/jpeg", "main".getBytes()));
+        request.setLogoImg(new MockMultipartFile("logoImg", "logo.jpg", "image/jpeg", "logo".getBytes()));
+        request.setStartBackground(new MockMultipartFile("startBackground", "bg.jpg", "image/jpeg", "bg".getBytes()));
+        return request;
+    }
+
+    // 이미지 없는 요청 객체 생성 메소드
+    private StoreRequest createStoreRequestWithoutImages() {
+        StoreRequest request = new StoreRequest();
+        request.setName("테스트매장");
+        request.setPhone("010-1234-5678");
+        request.setAddress("서울시 어딘가");
+        request.setIntroduction("소개입니다.");
+        request.setMainColor("#002F6C");
+        request.setSubColor("#0051A3");
+        request.setTextColor("#F8F9FA");
+        return request;
+    }
+}
+

--- a/admin-service/src/test/java/com/samnammae/admin_service/service/impl/LocalFileStorageServiceTest.java
+++ b/admin-service/src/test/java/com/samnammae/admin_service/service/impl/LocalFileStorageServiceTest.java
@@ -1,0 +1,164 @@
+package com.samnammae.admin_service.service.impl;
+
+import com.samnammae.common.exception.CustomException;
+import com.samnammae.common.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.*;
+
+class LocalFileStorageServiceTest {
+
+    private LocalFileStorageService fileStorageService;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        fileStorageService = new LocalFileStorageService();
+        // ReflectionTestUtils를 사용하여 private 필드에 값 주입
+        ReflectionTestUtils.setField(fileStorageService, "uploadDir", tempDir.toString());
+    }
+
+    @Test
+    @DisplayName("파일 업로드 성공 테스트")
+    void upload_success() {
+        // given
+        String fileName = "test-file.jpg";
+        String contentType = "image/jpeg";
+        byte[] content = "test image content".getBytes();
+        MultipartFile file = new MockMultipartFile("file", fileName, contentType, content);
+
+        // when
+        String savedPath = fileStorageService.upload(file);
+
+        // then
+        assertThat(savedPath).isNotNull();
+        assertThat(savedPath).startsWith("/files/");
+
+        // 파일이 실제로 저장되었는지 확인
+        File[] files = tempDir.toFile().listFiles();
+        assertThat(files).isNotNull();
+        assertThat(files).hasSize(1);
+
+        String uuid = savedPath.substring(7); // "/files/" 제외
+        assertThat(files[0].getName()).isEqualTo(uuid);
+
+        // 파일 내용 확인
+        try {
+            byte[] savedContent = Files.readAllBytes(files[0].toPath());
+            assertThat(savedContent).isEqualTo(content);
+        } catch (IOException e) {
+            fail("파일을 읽는 중 예외 발생", e);
+        }
+    }
+
+    @Test
+    @DisplayName("확장자가 없는 파일 업로드 테스트")
+    void upload_fileWithoutExtension() {
+        // given
+        String fileName = "test-file-without-extension";
+        String contentType = "application/octet-stream";
+        byte[] content = "test content without extension".getBytes();
+        MultipartFile file = new MockMultipartFile("file", fileName, contentType, content);
+
+        // when
+        String savedPath = fileStorageService.upload(file);
+
+        // then
+        assertThat(savedPath).isNotNull();
+
+        // 파일이 실제로 저장되었는지 확인
+        File[] files = tempDir.toFile().listFiles();
+        assertThat(files).isNotNull();
+        assertThat(files).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("null 파일명 처리 테스트")
+    void upload_nullFilename() {
+        // given
+        String contentType = "application/octet-stream";
+        byte[] content = "test content with null filename".getBytes();
+        MultipartFile file = new MockMultipartFile("file", null, contentType, content);
+
+        // when
+        String savedPath = fileStorageService.upload(file);
+
+        // then
+        assertThat(savedPath).isNotNull();
+
+        // 파일이 실제로 저장되었는지 확인
+        File[] files = tempDir.toFile().listFiles();
+        assertThat(files).isNotNull();
+        assertThat(files).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("파일 업로드 중 IOException 발생 시 CustomException 반환")
+    void upload_fail_dueToIOException() throws IOException {
+        // given
+        MultipartFile mockFile = Mockito.mock(MultipartFile.class);
+        Mockito.when(mockFile.getOriginalFilename()).thenReturn("test.png");
+        Mockito.doThrow(new IOException("disk full")).when(mockFile).transferTo(Mockito.any(File.class));
+
+        // when and then
+        assertThatThrownBy(() -> fileStorageService.upload(mockFile))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    CustomException ce = (CustomException) e;
+                    assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.FILE_UPLOAD_FAILED);
+                });
+    }
+
+    @Test
+    @DisplayName("getExtension 메소드 테스트 - 정상 파일명")
+    void getExtension_normalFilename() {
+        // given
+        String filename = "test.jpg";
+
+        // when
+        String extension = ReflectionTestUtils.invokeMethod(fileStorageService, "getExtension", filename);
+
+        // then
+        assertThat(extension).isEqualTo(".jpg");
+    }
+
+    @Test
+    @DisplayName("getExtension 메소드 테스트 - null 파일명")
+    void getExtension_nullFilename() {
+        // given
+        String filename = null;
+
+        // when
+        String extension = ReflectionTestUtils.invokeMethod(fileStorageService, "getExtension", filename);
+
+        // then
+        assertThat(extension).isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("getExtension 메소드 테스트 - 확장자 없는 파일명")
+    void getExtension_filenameWithoutExtension() {
+        // given
+        String filename = "testfile";
+
+        // when
+        String extension = ReflectionTestUtils.invokeMethod(fileStorageService, "getExtension", filename);
+
+        // then
+        assertThat(extension).isEqualTo("");
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,7 @@
 rootProject.name = 'IncluKiosk-BE'
 
-include 'api-gateway'
-include 'config-server'
-include 'eureka-server'
+include('api-gateway', 'config-server', 'eureka-server')
 
 include 'common-module'
 
-include 'auth-service'
+include('auth-service', 'admin-service')


### PR DESCRIPTION
## ✨ 주요 변경 사항
- 매장 등록 API `(POST /api/admin/store)` 구현
- 이미지가 선택되지 않은 경우(null)도 내부 로직에서 안전하게 처리
- 파일 업로드 실패 시 `CustomException(FILE_UPLOAD_FAILED)` 예외 반환

## 🧪 테스트
- 단위 테스트: `LocalFileStorageServiceTest`
  - 정상 파일 업로드 및 확장자 처리
  - 확장자 없음, 파일명 null 등 edge case 처리
  - IOException 발생 시 예외 전환 여부 검증
- 슬라이스 테스트: `StoreControllerTest`
  - 필드 누락 없이 모든 이미지 포함 시 정상 등록(200 OK)
  - 서비스 예외 발생 시 5xx 오류 및 메시지 검증
  - multipart 기반 요청 시 파라미터 바인딩 및 응답 형식 검증

## 🔗 관련 이슈
Closes #12 