### PR TITLE
feat : 매장 등록 API 요청 헤더 추가

### DIFF
--- a/admin-service/src/main/java/com/samnammae/admin_service/controller/StoreController.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/controller/StoreController.java
@@ -7,10 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -24,6 +21,7 @@ public class StoreController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "매장 등록", description = "매장 정보를 입력하여 새로운 매장을 등록합니다.")
     public ApiResponse<Long> registerStore(
+            @RequestHeader("X-User-Id") Long userId,
             @RequestPart("request") StoreRequest request,
             @RequestPart(value = "mainImg", required = false) MultipartFile mainImg,
             @RequestPart(value = "logoImg", required = false) MultipartFile logoImg,
@@ -32,7 +30,7 @@ public class StoreController {
         request.setMainImg(mainImg);
         request.setLogoImg(logoImg);
         request.setStartBackground(startBackground);
-        Long storeId = storeService.createStore(request);
+        Long storeId = storeService.createStore(userId, request);
         return ApiResponse.success(storeId);
     }
 }

--- a/admin-service/src/main/java/com/samnammae/admin_service/domain/store/Store.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/domain/store/Store.java
@@ -16,6 +16,9 @@ public class Store {
     private Long id;
 
     @Column(nullable = false)
+    private Long ownerId;   // 매장 소유자 ID (관리자 ID)
+
+    @Column(nullable = false)
     private String name;         // 매장 이름
 
     @Column(nullable = false)

--- a/admin-service/src/main/java/com/samnammae/admin_service/service/StoreService.java
+++ b/admin-service/src/main/java/com/samnammae/admin_service/service/StoreService.java
@@ -17,12 +17,13 @@ public class StoreService {
     private final FileStorageService fileStorageService;
 
     // 가게 등록
-    public Long createStore(StoreRequest request) {
+    public Long createStore(Long ownerId, StoreRequest request) {
         String mainImgUrl = uploadFile(request.getMainImg());
         String logoImgUrl = uploadFile(request.getLogoImg());
         String backgroundUrl = uploadFile(request.getStartBackground());
 
         Store store = Store.builder()
+                .ownerId(ownerId)
                 .name(request.getName())
                 .phone(request.getPhone())
                 .address(request.getAddress())


### PR DESCRIPTION
## ✨ 주요 변경 사항
- 매장 등록 API `(POST /api/admin/store)` 요청 헤더에 `X-User-Id`추가

## 🧪 테스트
- 단위 테스트: `StoreServiceTest`
- 슬라이스 테스트: `StoreControllerTest`

## 🔗 관련 이슈
Closes #12 