### PR TITLE
feat : API Gateway에서 사용자 관리 매장 ID 목록 헤더 추가

### DIFF
--- a/api-gateway/src/main/java/com/samnammae/api_gateway/exception/GatewayExceptionHandler.java
+++ b/api-gateway/src/main/java/com/samnammae/api_gateway/exception/GatewayExceptionHandler.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.samnammae.common.exception.CustomException;
 import com.samnammae.common.exception.ErrorCode;
 import com.samnammae.common.response.ApiResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -17,8 +19,10 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 @Component
-@Order(-1) // 다른 스프링 기본 핸들러보다 우선순위를 높게 설정하여 먼저 실행되도록 함
+@Order(-1)
 public class GatewayExceptionHandler implements ErrorWebExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(GatewayExceptionHandler.class);
 
     private final ObjectMapper objectMapper;
 
@@ -31,34 +35,41 @@ public class GatewayExceptionHandler implements ErrorWebExceptionHandler {
     public Mono<Void> handle(ServerWebExchange exchange, @NonNull Throwable ex) {
         ServerHttpResponse response = exchange.getResponse();
 
-        // 이미 응답이 커밋된 경우, 더 이상 처리하지 않음
         if (response.isCommitted()) {
             return Mono.error(ex);
         }
 
-        // 응답 헤더 설정
         response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
 
         ErrorCode errorCode;
-        // 우리가 직접 정의한 CustomException인 경우, 해당 ErrorCode를 사용
         if (ex instanceof CustomException) {
-            errorCode = ((CustomException) ex).getErrorCode();
+            CustomException customEx = (CustomException) ex;
+            errorCode = customEx.getErrorCode();
+
+            // CustomException의 경우 WARN 레벨로 로깅
+            logger.warn("Gateway Custom Exception - Code: {}, Message: {}, Path: {}",
+                    errorCode.name(), errorCode.getMessage(),
+                    exchange.getRequest().getPath().value(), ex);
         } else {
-            // 그 외 처리하지 않은 예외는 일반적인 서버 에러로 처리 (필요에 따라 확장 가능)
             errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+
+            // 예상치 못한 예외의 경우 ERROR 레벨로 로깅
+            logger.error("Gateway Unexpected Exception - Path: {}, Exception: {}",
+                    exchange.getRequest().getPath().value(), ex.getClass().getSimpleName(), ex);
         }
 
         response.setStatusCode(HttpStatus.valueOf(errorCode.getStatus()));
         ApiResponse<Object> apiResponse = ApiResponse.error(errorCode.getStatus(), errorCode.getMessage());
 
         try {
-            // ApiResponse 객체를 JSON 바이트로 변환
             byte[] errorBytes = objectMapper.writeValueAsBytes(apiResponse);
             DataBuffer buffer = response.bufferFactory().wrap(errorBytes);
-            // 응답 스트림에 에러 데이터 작성
             return response.writeWith(Mono.just(buffer));
         } catch (JsonProcessingException e) {
-            // JSON 변환 실패 시, 내부 서버 에러로 응답
+            // JSON 변환 실패 시 ERROR 레벨로 로깅
+            logger.error("Failed to serialize error response to JSON - Path: {}",
+                    exchange.getRequest().getPath().value(), e);
+
             response.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
             return response.setComplete();
         }

--- a/api-gateway/src/main/java/com/samnammae/api_gateway/filter/AuthorizationHeaderGatewayFilterFactory.java
+++ b/api-gateway/src/main/java/com/samnammae/api_gateway/filter/AuthorizationHeaderGatewayFilterFactory.java
@@ -46,10 +46,12 @@ public class AuthorizationHeaderGatewayFilterFactory extends AbstractGatewayFilt
                 Claims claims = jwtUtil.validateAndParseClaims(token);
                 String userId = claims.getSubject();
                 String userEmail = claims.get("userEmail", String.class);
+                String storeIds = claims.get("storeIds", String.class);
 
                 ServerHttpRequest newRequest = request.mutate()
                         .header("X-USER-ID", userId)
                         .header("X-USER-EMAIL", userEmail)
+                        .header("X-MANAGED-STORE-IDS", storeIds)
                         .build();
 
                 return chain.filter(exchange.mutate().request(newRequest).build());

--- a/api-gateway/src/main/java/com/samnammae/api_gateway/filter/AuthorizationHeaderGatewayFilterFactory.java
+++ b/api-gateway/src/main/java/com/samnammae/api_gateway/filter/AuthorizationHeaderGatewayFilterFactory.java
@@ -4,6 +4,8 @@ import com.samnammae.api_gateway.util.JwtUtil;
 import com.samnammae.common.exception.CustomException;
 import com.samnammae.common.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.http.HttpHeaders;
@@ -11,10 +13,13 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Objects;
 
 @Component
 public class AuthorizationHeaderGatewayFilterFactory extends AbstractGatewayFilterFactory<AuthorizationHeaderGatewayFilterFactory.Config> {
+
+    private static final Logger logger = LoggerFactory.getLogger(AuthorizationHeaderGatewayFilterFactory.class);
 
     private final JwtUtil jwtUtil;
 
@@ -31,10 +36,12 @@ public class AuthorizationHeaderGatewayFilterFactory extends AbstractGatewayFilt
     public GatewayFilter apply(Config config) {
         return (exchange, chain) -> {
             ServerHttpRequest request = exchange.getRequest();
+            String requestPath = request.getPath().value();
 
             // 'Authorization' 헤더 존재 여부 확인
             if (!request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
-                // 에러 발생 시, 스트림에 에러 신호를 보냄 (글로벌 핸들러가 처리)
+                logger.warn("Authorization header missing - Path: {}, RemoteAddress: {}",
+                        requestPath, request.getRemoteAddress());
                 return Mono.error(new CustomException(ErrorCode.TOKEN_MISSING));
             }
 
@@ -46,7 +53,19 @@ public class AuthorizationHeaderGatewayFilterFactory extends AbstractGatewayFilt
                 Claims claims = jwtUtil.validateAndParseClaims(token);
                 String userId = claims.getSubject();
                 String userEmail = claims.get("userEmail", String.class);
-                String storeIds = claims.get("storeIds", String.class);
+                Object storeIdsObj = claims.get("storeIds");
+                List<Long> storeIdsList = null;
+                if (storeIdsObj instanceof List<?>) {
+                    storeIdsList = ((List<?>) storeIdsObj).stream()
+                            .filter(item -> item instanceof Number)
+                            .map(item -> ((Number) item).longValue())
+                            .toList();
+                }
+                String storeIds = storeIdsList != null ?
+                        storeIdsList.stream().map(String::valueOf).collect(java.util.stream.Collectors.joining(",")) : "";
+
+                logger.debug("JWT validation successful - Path: {}, UserId: {}, UserEmail: {}",
+                        requestPath, userId, userEmail);
 
                 ServerHttpRequest newRequest = request.mutate()
                         .header("X-USER-ID", userId)
@@ -57,7 +76,8 @@ public class AuthorizationHeaderGatewayFilterFactory extends AbstractGatewayFilt
                 return chain.filter(exchange.mutate().request(newRequest).build());
 
             } catch (CustomException e) {
-                // 이 신호는 GatewayExceptionHandler가 처리합니다.
+                logger.warn("JWT validation failed - Path: {}, ErrorCode: {}, RemoteAddress: {}",
+                        requestPath, e.getErrorCode().name(), request.getRemoteAddress());
                 return Mono.error(e);
             }
         };

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -27,6 +27,14 @@ spring:
                 - Path=/api/admin/**
               filters:
                 - AuthorizationHeader
+
+            # Menu 서비스 라우팅 규칙
+            - id: menu-service-route
+              uri: lb://menu-service # 로드 밸런싱을 통해 menu-service로
+              predicates:
+                - Path=/api/menu/**
+              filters:
+                - AuthorizationHeader
           default-filters:
             - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials
           globalcors:
@@ -44,6 +52,7 @@ spring:
                   - GET
                   - POST
                   - PUT
+                  - PATCH
                   - DELETE
                   - OPTIONS
                 allowedHeaders:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,19 +32,19 @@ services:
       - my-msa-network
 
   # 1.3. Menu Service용 MySQL 데이터베이스
-#  mysql-db-menu:
-#    image: mysql:8.0
-#    ports:
-#      - "3308:3306" # 호스트 포트 3308을 컨테이너 포트 3306에 매핑 (다른 DB와 중복되지 않게)
-#    environment:
-#      MYSQL_ROOT_PASSWORD: your_root_password_for_menu_db # 강력하고 안전한 비밀번호로 변경하세요!
-#      MYSQL_DATABASE: menu_db # Menu Service가 사용할 데이터베이스 이름
-#      MYSQL_USER: menu_user
-#      MYSQL_PASSWORD: menu_password
-#    volumes:
-#      - mysql-data-menu:/var/lib/mysql
-#    networks:
-#      - my-msa-network
+  mysql-db-menu:
+    image: mysql:8.0
+    ports:
+      - "3309:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MENU_DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: menu_db # Menu Service가 사용할 데이터베이스 이름
+      MYSQL_USER: ${MENU_DB_USER}
+      MYSQL_PASSWORD: ${MENU_DB_PASSWORD}
+    volumes:
+      - mysql-data-menu:/var/lib/mysql
+    networks:
+      - my-msa-network
 
   # 1.4. Order Service용 MongoDB 데이터베이스 (MongoDB 사용 시)
 #  mongodb-order:
@@ -130,22 +130,22 @@ services:
 #      - my-msa-network
 
   # 3.3. Menu Service
-#  menu-service:
-#    build:
-#      context: ./menu-service-project
-#      dockerfile: Dockerfile
-#    ports:
-#      - "8084:8084"
-#    environment:
-#      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://eureka-server:8761/eureka
-#      - DB_URL=jdbc:mysql://mysql-db-menu:3306/menu_db?useSSL=false&serverTimezone=Asia/Seoul
-#      - DB_USERNAME=${MENU_DB_USER}
-#      - DB_PASSWORD=${MENU_DB_PASSWORD}
-#    depends_on:
-#      - eureka-server
-#      - mysql-db-menu
-#    networks:
-#      - my-msa-network
+  menu-service:
+    build:
+      context: ./menu-service
+      dockerfile: Dockerfile
+    ports:
+      - "8083:8083"
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://eureka-server:8761/eureka
+      - DB_URL=jdbc:mysql://mysql-db-menu:3306/menu_db?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+      - DB_USERNAME=${MENU_DB_USER}
+      - DB_PASSWORD=${MENU_DB_PASSWORD}
+    depends_on:
+      - eureka-server
+      - mysql-db-menu
+    networks:
+      - my-msa-network
 
   # 3.4. Admin Service
   admin-service:

--- a/menu-service/src/main/java/com/samnammae/menu_service/controller/MenuCategoryController.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/controller/MenuCategoryController.java
@@ -51,7 +51,7 @@ public class MenuCategoryController {
 
     @PatchMapping("/{storeId}/category")
     @Operation(summary = "메뉴 카테고리 수정", description = "특정 매장의 메뉴 카테고리 목록을 일괄 수정합니다. (순서 변경 등)")
-    public ApiResponse<Void> updateCategories(
+    public ApiResponse<List<Long>> updateCategories(
             @PathVariable Long storeId,
             @RequestHeader("X-MANAGED-STORE-IDS") String managedStoreIds,
             @RequestBody List<MenuCategoryUpdateRequestDto> requestDto) {
@@ -61,7 +61,7 @@ public class MenuCategoryController {
         // 카테고리 목록 수정
         List<Long> updatedCategoryIds = menuCategoryService.updateCategories(storeId, requestDto);
 
-        return ApiResponse.success(null);
+        return ApiResponse.success(updatedCategoryIds);
     }
 
     @DeleteMapping("/{storeId}/category/{categoryId}")


### PR DESCRIPTION
## ✨ 주요 변경 사항
- **API Gateway**:
    - JWT 토큰의 `storeIds` 정보를 `X-MANAGED-STORE-IDS` 헤더에 추가
    - `/api/menu/**` 경로에 대한 라우팅 규칙을 추가
    - 전역 CORS(Cross-Origin Resource Sharing) 설정에 `PATCH` 메서드를 허용
    - 예외 처리 핸들러, 필터에 로깅 추가
- **Menu Service**:
    - 메뉴 카테고리 수정 API의 응답 타입을 `Void`에서 `List<Long>` (수정된 ID 목록)으로 변경
- **Docker**:
    - `docker-compose.yml`에 `menu-service`와 관련 설정

## 🧪 테스트
- 단위 테스트: `AuthorizationHeaderGatewayFilterFactoryTest`

## 🔗 관련 이슈
Closes #32 