### PR TITLE
feat : 옵션 CRUD API 구현

### DIFF
--- a/common-module/src/main/java/com/samnammae/common/exception/ErrorCode.java
+++ b/common-module/src/main/java/com/samnammae/common/exception/ErrorCode.java
@@ -30,6 +30,11 @@ public enum ErrorCode {
     INVALID_FILE_NAME(400, "파일 이름이 없습니다."),
     FILE_IO_ERROR(500, "파일 입출력 오류가 발생했습니다."),
     S3_SERVICE_ERROR(500, "S3 서비스 오류가 발생했습니다."),
+    OPTION_CATEGORY_ID_DUPLICATED(400, "이미 존재하는 옵션 카테고리 ID입니다."),
+    OPTION_CATEGORY_NOT_FOUND(404, "옵션 카테고리를 찾을 수 없습니다."),
+    OPTION_NOT_FOUND(404, "옵션을 찾을 수 없습니다."),
+    OPTION_CATEGORY_TYPE_MISMATCH(400, "옵션 카테고리 타입이 일치하지 않습니다."),
+    OPTION_CATEGORY_NAME_DUPLICATED(400, "이미 존재하는 옵션 카테고리 이름입니다."),
 
     // Api Gateway
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),

--- a/menu-service/src/main/java/com/samnammae/menu_service/controller/OptionController.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/controller/OptionController.java
@@ -1,0 +1,102 @@
+package com.samnammae.menu_service.controller;
+
+import com.samnammae.common.response.ApiResponse;
+import com.samnammae.menu_service.dto.request.OptionCategoryRequestDto;
+import com.samnammae.menu_service.dto.response.OptionCategoryResponseDto;
+import com.samnammae.menu_service.service.OptionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/menu")
+@Tag(name = "Option", description = "옵션 관리 API")
+@RequiredArgsConstructor
+public class OptionController {
+
+    private final OptionService optionService;
+
+    @PostMapping("/{storeId}/option")
+    @Operation(summary = "옵션 추가", description = "새로운 옵션 카테고리와 하위 옵션들을 추가합니다.")
+    public ApiResponse<Long> createOptionCategory(
+            @PathVariable Long storeId,
+            @RequestHeader("X-MANAGED-STORE-IDS") String managedStoreIds,
+            @RequestBody OptionCategoryRequestDto requestDto) {
+
+        // 매장 접근 권한 검증
+        optionService.validateStoreAccess(storeId, managedStoreIds);
+
+        // 옵션 카테고리 생성
+        Long optionCategoryId = optionService.createOptionCategory(storeId, requestDto);
+
+        return ApiResponse.success(optionCategoryId);
+    }
+
+    @GetMapping("/{storeId}/option")
+    @Operation(summary = "옵션 목록 조회", description = "특정 매장의 전체 옵션을 조회합니다.")
+    public ApiResponse<List<OptionCategoryResponseDto>> getOptions(
+            @PathVariable Long storeId,
+            @RequestHeader("X-MANAGED-STORE-IDS") String managedStoreIds) {
+
+        // 매장 접근 권한 검증
+        optionService.validateStoreAccess(storeId, managedStoreIds);
+
+        // 옵션 목록 조회
+        List<OptionCategoryResponseDto> response = optionService.getOptionsByStore(storeId);
+
+        return ApiResponse.success(response);
+    }
+
+    @PutMapping("/{storeId}/option/{optionCategoryId}")
+    @Operation(summary = "옵션 수정", description = "기존 옵션 카테고리와 하위 옵션들을 수정합니다.")
+    public ApiResponse<Long> updateOptionCategory(
+            @PathVariable Long storeId,
+            @PathVariable Long optionCategoryId,
+            @RequestHeader("X-MANAGED-STORE-IDS") String managedStoreIds,
+            @RequestBody OptionCategoryRequestDto requestDto) {
+
+        // 매장 접근 권한 검증
+        optionService.validateStoreAccess(storeId, managedStoreIds);
+
+        // 옵션 카테고리 수정
+        Long updatedId = optionService.updateOptionCategory(storeId, optionCategoryId, requestDto);
+
+        return ApiResponse.success(updatedId);
+    }
+
+    @DeleteMapping("/{storeId}/option/{optionCategoryId}")
+    @Operation(summary = "옵션 카테고리 삭제", description = "옵션 카테고리 및 하위 옵션 전체를 삭제합니다.")
+    public ApiResponse<Void> deleteOptionCategory(
+            @PathVariable Long storeId,
+            @PathVariable Long optionCategoryId,
+            @RequestHeader("X-MANAGED-STORE-IDS") String managedStoreIds) {
+
+        // 매장 접근 권한 검증
+        optionService.validateStoreAccess(storeId, managedStoreIds);
+
+        // 옵션 카테고리 삭제
+        optionService.deleteOptionCategory(storeId, optionCategoryId);
+
+        return ApiResponse.success(null);
+    }
+
+    @DeleteMapping("/{storeId}/option/{optionCategoryId}/{optionId}")
+    @Operation(summary = "개별 옵션 삭제", description = "특정 카테고리 내의 개별 옵션을 삭제합니다.")
+    public ApiResponse<Void> deleteOption(
+            @PathVariable Long storeId,
+            @PathVariable Long optionCategoryId,
+            @PathVariable Long optionId,
+            @RequestHeader("X-MANAGED-STORE-IDS") String managedStoreIds) {
+
+        // 매장 접근 권한 검증
+        optionService.validateStoreAccess(storeId, managedStoreIds);
+
+        // 개별 옵션 삭제
+        optionService.deleteOption(storeId, optionCategoryId, optionId);
+
+        return ApiResponse.success(null);
+    }
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/domain/option/Option.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/domain/option/Option.java
@@ -1,0 +1,40 @@
+package com.samnammae.menu_service.domain.option;
+
+import com.samnammae.menu_service.domain.optioncategory.OptionCategory;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "options",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_option_category_custom",
+                        columnNames = {"option_category_id", "name"}
+                )
+        }
+)
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Option {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "option_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_category_id", nullable = false)
+    private OptionCategory optionCategory;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(name = "is_default", nullable = false)
+    private boolean isDefault;
+
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/domain/option/OptionRepository.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/domain/option/OptionRepository.java
@@ -1,0 +1,6 @@
+package com.samnammae.menu_service.domain.option;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OptionRepository extends JpaRepository<Option, Long> {
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/domain/optioncategory/OptionCategory.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/domain/optioncategory/OptionCategory.java
@@ -1,0 +1,53 @@
+package com.samnammae.menu_service.domain.optioncategory;
+
+import com.samnammae.menu_service.domain.option.Option;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "option_category",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_option_category_store_custom",
+                        columnNames = {"storeId", "name"}
+                )
+        }
+)
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OptionCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "option_category_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Long storeId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OptionCategoryType type;
+
+    @Column(nullable = false)
+    private boolean isRequired;
+
+    @OneToMany(mappedBy = "optionCategory", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Option> options = new ArrayList<>();
+
+    // update 메서드
+    public void update(String name, OptionCategoryType type, boolean isRequired) {
+        this.name = name;
+        this.type = type;
+        this.isRequired = isRequired;
+    }
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/domain/optioncategory/OptionCategoryRepository.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/domain/optioncategory/OptionCategoryRepository.java
@@ -1,0 +1,17 @@
+package com.samnammae.menu_service.domain.optioncategory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OptionCategoryRepository extends JpaRepository<OptionCategory, Long> {
+    @Query("SELECT oc FROM OptionCategory oc LEFT JOIN FETCH oc.options WHERE oc.storeId = :storeId")
+    List<OptionCategory> findAllByStoreIdWithDetails(@Param("storeId") Long storeId);
+
+    Optional<OptionCategory> findByIdAndStoreId(Long id, Long storeId);
+
+    boolean existsByStoreIdAndName(Long storeId, String name);
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/domain/optioncategory/OptionCategoryType.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/domain/optioncategory/OptionCategoryType.java
@@ -1,0 +1,6 @@
+package com.samnammae.menu_service.domain.optioncategory;
+
+public enum OptionCategoryType {
+    SINGLE_CHOICE,  // 단일 선택
+    MULTIPLE_CHOICE // 다중 선택
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/domain/optioncategory/OptionCategoryType.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/domain/optioncategory/OptionCategoryType.java
@@ -1,6 +1,6 @@
 package com.samnammae.menu_service.domain.optioncategory;
 
 public enum OptionCategoryType {
-    SINGLE_CHOICE,  // 단일 선택
-    MULTIPLE_CHOICE // 다중 선택
+    SINGLE,  // 단일 선택
+    MULTIPLE // 다중 선택
 }

--- a/menu-service/src/main/java/com/samnammae/menu_service/dto/request/OptionCategoryRequestDto.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/dto/request/OptionCategoryRequestDto.java
@@ -1,0 +1,16 @@
+package com.samnammae.menu_service.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OptionCategoryRequestDto {
+    private String name;
+    private String type; // "SINGLE" 또는 "MULTIPLE"
+    private boolean required;
+    private List<OptionRequestDto> options;
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/dto/request/OptionRequestDto.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/dto/request/OptionRequestDto.java
@@ -1,0 +1,14 @@
+package com.samnammae.menu_service.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OptionRequestDto {
+    private String name;
+    private int price;
+    private boolean isDefault;
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/dto/response/OptionCategoryResponseDto.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/dto/response/OptionCategoryResponseDto.java
@@ -1,0 +1,25 @@
+package com.samnammae.menu_service.dto.response;
+
+import com.samnammae.menu_service.domain.optioncategory.OptionCategory;
+import lombok.Getter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class OptionCategoryResponseDto {
+    private final Long id;
+    private final String name;
+    private final String type;
+    private final boolean required;
+    private final List<OptionResponseDto> options;
+
+    public OptionCategoryResponseDto(OptionCategory category) {
+        this.id = category.getId();
+        this.name = category.getName();
+        this.type = category.getType().name();
+        this.required = category.isRequired();
+        this.options = category.getOptions().stream()
+                .map(OptionResponseDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/dto/response/OptionResponseDto.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/dto/response/OptionResponseDto.java
@@ -1,0 +1,19 @@
+package com.samnammae.menu_service.dto.response;
+
+import com.samnammae.menu_service.domain.option.Option;
+import lombok.Getter;
+
+@Getter
+public class OptionResponseDto {
+    private final Long id;
+    private final String name;
+    private final int price;
+    private final boolean isDefault;
+
+    public OptionResponseDto(Option option) {
+        this.id = option.getId();
+        this.name = option.getName();
+        this.price = option.getPrice();
+        this.isDefault = option.isDefault();
+    }
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/service/OptionService.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/service/OptionService.java
@@ -1,0 +1,131 @@
+package com.samnammae.menu_service.service;
+
+import com.samnammae.common.exception.CustomException;
+import com.samnammae.common.exception.ErrorCode;
+import com.samnammae.menu_service.domain.option.Option;
+import com.samnammae.menu_service.domain.optioncategory.OptionCategory;
+import com.samnammae.menu_service.domain.optioncategory.OptionCategoryRepository;
+import com.samnammae.menu_service.domain.optioncategory.OptionCategoryType;
+import com.samnammae.menu_service.dto.request.OptionCategoryRequestDto;
+import com.samnammae.menu_service.dto.request.OptionRequestDto;
+import com.samnammae.menu_service.dto.response.OptionCategoryResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OptionService {
+
+    private final OptionCategoryRepository optionCategoryRepository;
+
+    public void validateStoreAccess(Long storeId, String managedStoreIds) {
+        List<Long> accessibleStoreIds = Arrays.stream(managedStoreIds.split(",")).map(Long::parseLong).toList();
+        if (!accessibleStoreIds.contains(storeId)) {
+            throw new CustomException(ErrorCode.STORE_ACCESS_DENIED);
+        }
+    }
+
+    @Transactional
+    public Long createOptionCategory(Long storeId, OptionCategoryRequestDto requestDto) {
+        // 옵션 카테고리 이름 중복 검증
+        if (optionCategoryRepository.existsByStoreIdAndName(storeId, requestDto.getName())) {
+            throw new CustomException(ErrorCode.OPTION_CATEGORY_NAME_DUPLICATED);
+        }
+
+        // 옵션 카테고리 생성
+        OptionCategory category = OptionCategory.builder()
+                .storeId(storeId)
+                .name(requestDto.getName())
+                .type(OptionCategoryType.valueOf(requestDto.getType()))
+                .isRequired(requestDto.isRequired())
+                .build();
+
+        // 옵션 카테고리에 속하는 옵션들을 생성
+        List<Option> options = requestDto.getOptions().stream()
+                .map(optionDto -> buildOption(optionDto, category))
+                .toList();
+
+        // 옵션 카테고리에 옵션 추가
+        category.getOptions().addAll(options);
+
+        // 옵션 카테고리 저장
+        OptionCategory savedCategory = optionCategoryRepository.save(category);
+        return savedCategory.getId();
+    }
+
+    // 매장별 옵션 카테고리 조회
+    public List<OptionCategoryResponseDto> getOptionsByStore(Long storeId) {
+        return optionCategoryRepository.findAllByStoreIdWithDetails(storeId).stream()
+                .map(OptionCategoryResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+
+    @Transactional
+    public Long updateOptionCategory(Long storeId, Long optionCategoryId, OptionCategoryRequestDto requestDto) {
+        // 옵션 카테고리 조회
+        OptionCategory category = optionCategoryRepository.findByIdAndStoreId(optionCategoryId, storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.OPTION_CATEGORY_NOT_FOUND));
+
+        // 이름이 변경되는 경우 중복 검증 필요
+        if (!category.getName().equals(requestDto.getName()) &&
+                optionCategoryRepository.existsByStoreIdAndName(storeId, requestDto.getName())) {
+            throw new CustomException(ErrorCode.OPTION_CATEGORY_NAME_DUPLICATED);
+        }
+
+        category.update(
+                requestDto.getName(),
+                OptionCategoryType.valueOf(requestDto.getType()),
+                requestDto.isRequired()
+        );
+
+        // 옵션 카테고리 정보 업데이트
+        category.getOptions().clear();
+        List<Option> newOptions = requestDto.getOptions().stream()
+                .map(optionDto -> buildOption(optionDto, category))
+                .toList();
+        category.getOptions().addAll(newOptions);
+
+        return category.getId();
+    }
+
+    @Transactional
+    public void deleteOptionCategory(Long storeId, Long optionCategoryId) {
+        OptionCategory category = optionCategoryRepository.findByIdAndStoreId(optionCategoryId, storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.OPTION_CATEGORY_NOT_FOUND));
+        optionCategoryRepository.delete(category);
+    }
+
+
+    @Transactional
+    public void deleteOption(Long storeId, Long optionCategoryId, Long optionId) {
+        // 옵션 카테고리 조회
+        OptionCategory category = optionCategoryRepository.findByIdAndStoreId(optionCategoryId, storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.OPTION_CATEGORY_NOT_FOUND));
+
+
+        // 옵션 ID로 개별 옵션 조회
+        Option optionToDelete = category.getOptions().stream()
+                .filter(opt -> opt.getId().equals(optionId))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.OPTION_NOT_FOUND));
+
+        // 옵션 삭제(JPA의 orphanRemoval을 사용하여 자동으로 삭제됨)
+        category.getOptions().remove(optionToDelete);
+    }
+
+    private Option buildOption(OptionRequestDto dto, OptionCategory category) {
+        return Option.builder()
+                .name(dto.getName())
+                .price(dto.getPrice())
+                .isDefault(dto.isDefault())
+                .optionCategory(category)
+                .build();
+    }
+}

--- a/menu-service/src/test/java/com/samnammae/menu_service/controller/OptionControllerTest.java
+++ b/menu-service/src/test/java/com/samnammae/menu_service/controller/OptionControllerTest.java
@@ -1,0 +1,177 @@
+package com.samnammae.menu_service.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.samnammae.common.exception.CustomException;
+import com.samnammae.common.exception.ErrorCode;
+import com.samnammae.menu_service.dto.request.OptionCategoryRequestDto;
+import com.samnammae.menu_service.dto.response.OptionCategoryResponseDto;
+import com.samnammae.menu_service.service.OptionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OptionController.class)
+class OptionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private OptionService optionService;
+
+    private final Long storeId = 1L;
+    private final Long categoryId = 1L;
+    private final Long optionId = 101L;
+    private final String managedStoreIds = "1,2,3";
+
+    @Test
+    @DisplayName("옵션 생성 - 성공")
+    void createOptionCategory_Success() throws Exception {
+        // Given
+        OptionCategoryRequestDto requestDto = new OptionCategoryRequestDto(); // DTO 필드 설정 필요
+        when(optionService.createOptionCategory(eq(storeId), any(OptionCategoryRequestDto.class)))
+                .thenReturn(categoryId);
+
+        // When & Then
+        mockMvc.perform(post("/api/menu/{storeId}/option", storeId)
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(categoryId));
+
+        verify(optionService).validateStoreAccess(storeId, managedStoreIds);
+        verify(optionService).createOptionCategory(eq(storeId), any(OptionCategoryRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("옵션 생성 - 매장 접근 권한 없음")
+    void createOptionCategory_AccessDenied() throws Exception {
+        // Given
+        OptionCategoryRequestDto requestDto = new OptionCategoryRequestDto();
+        doThrow(new CustomException(ErrorCode.STORE_ACCESS_DENIED))
+                .when(optionService).validateStoreAccess(storeId, managedStoreIds);
+
+        // When & Then
+        mockMvc.perform(post("/api/menu/{storeId}/option", storeId)
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isForbidden());
+
+        verify(optionService).validateStoreAccess(storeId, managedStoreIds);
+        verify(optionService, never()).createOptionCategory(any(), any());
+    }
+
+    @Test
+    @DisplayName("옵션 목록 조회 - 성공")
+    void getOptions_Success() throws Exception {
+        // Given
+        List<OptionCategoryResponseDto> response = Collections.emptyList(); // 테스트용 응답 DTO 생성 필요
+        when(optionService.getOptionsByStore(storeId)).thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(get("/api/menu/{storeId}/option", storeId)
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray());
+
+        verify(optionService).validateStoreAccess(storeId, managedStoreIds);
+        verify(optionService).getOptionsByStore(storeId);
+    }
+
+    @Test
+    @DisplayName("옵션 수정 - 성공")
+    void updateOptionCategory_Success() throws Exception {
+        // Given
+        OptionCategoryRequestDto requestDto = new OptionCategoryRequestDto();
+        when(optionService.updateOptionCategory(eq(storeId), eq(categoryId), any(OptionCategoryRequestDto.class)))
+                .thenReturn(categoryId);
+
+        // When & Then
+        mockMvc.perform(put("/api/menu/{storeId}/option/{optionCategoryId}", storeId, categoryId)
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(categoryId));
+
+        verify(optionService).validateStoreAccess(storeId, managedStoreIds);
+        verify(optionService).updateOptionCategory(eq(storeId), eq(categoryId), any(OptionCategoryRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("옵션 수정 - 카테고리 없음")
+    void updateOptionCategory_NotFound() throws Exception {
+        // Given
+        OptionCategoryRequestDto requestDto = new OptionCategoryRequestDto();
+        when(optionService.updateOptionCategory(eq(storeId), eq(categoryId), any(OptionCategoryRequestDto.class)))
+                .thenThrow(new CustomException(ErrorCode.OPTION_CATEGORY_NOT_FOUND));
+
+        // When & Then
+        mockMvc.perform(put("/api/menu/{storeId}/option/{optionCategoryId}", storeId, categoryId)
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("옵션 카테고리 삭제 - 성공")
+    void deleteOptionCategory_Success() throws Exception {
+        // When & Then
+        mockMvc.perform(delete("/api/menu/{storeId}/option/{optionCategoryId}", storeId, categoryId)
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(optionService).validateStoreAccess(storeId, managedStoreIds);
+        verify(optionService).deleteOptionCategory(storeId, categoryId);
+    }
+
+    @Test
+    @DisplayName("개별 옵션 삭제 - 성공")
+    void deleteOption_Success() throws Exception {
+        // When & Then
+        mockMvc.perform(delete("/api/menu/{storeId}/option/{optionCategoryId}/{optionId}", storeId, categoryId, optionId)
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(optionService).validateStoreAccess(storeId, managedStoreIds);
+        verify(optionService).deleteOption(storeId, categoryId, optionId);
+    }
+
+    @Test
+    @DisplayName("개별 옵션 삭제 - 옵션 없음")
+    void deleteOption_NotFound() throws Exception {
+        // Given
+        doThrow(new CustomException(ErrorCode.OPTION_NOT_FOUND))
+                .when(optionService).deleteOption(storeId, categoryId, optionId);
+
+        // When & Then
+        mockMvc.perform(delete("/api/menu/{storeId}/option/{optionCategoryId}/{optionId}", storeId, categoryId, optionId)
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/menu-service/src/test/java/com/samnammae/menu_service/service/MenuServiceTest.java
+++ b/menu-service/src/test/java/com/samnammae/menu_service/service/MenuServiceTest.java
@@ -71,7 +71,7 @@ class MenuServiceTest {
                 .id(1L)
                 .storeId(1L)
                 .name("사이즈")
-                .type(OptionCategoryType.SINGLE_CHOICE)
+                .type(OptionCategoryType.SINGLE)
                 .isRequired(true)
                 .build();
 

--- a/menu-service/src/test/java/com/samnammae/menu_service/service/OptionServiceTest.java
+++ b/menu-service/src/test/java/com/samnammae/menu_service/service/OptionServiceTest.java
@@ -1,0 +1,212 @@
+package com.samnammae.menu_service.service;
+
+import com.samnammae.common.exception.CustomException;
+import com.samnammae.common.exception.ErrorCode;
+import com.samnammae.menu_service.domain.option.Option;
+import com.samnammae.menu_service.domain.option.OptionRepository;
+import com.samnammae.menu_service.domain.optioncategory.OptionCategory;
+import com.samnammae.menu_service.domain.optioncategory.OptionCategoryRepository;
+import com.samnammae.menu_service.domain.optioncategory.OptionCategoryType;
+import com.samnammae.menu_service.dto.request.OptionCategoryRequestDto;
+import com.samnammae.menu_service.dto.request.OptionRequestDto;
+import com.samnammae.menu_service.dto.response.OptionCategoryResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OptionServiceTest {
+
+    private final Long storeId = 1L;
+    private final Long categoryId = 1L;
+    private final Long optionId = 101L;
+    @Mock
+    private OptionCategoryRepository optionCategoryRepository;
+    @Mock
+    private OptionRepository optionRepository;
+    @InjectMocks
+    private OptionService optionService;
+    private OptionCategory testCategory;
+    private OptionCategoryRequestDto requestDto;
+
+    @BeforeEach
+    void setUp() {
+        testCategory = OptionCategory.builder()
+                .id(categoryId)
+                .storeId(storeId)
+                .name("사이즈")
+                .type(OptionCategoryType.SINGLE)
+                .isRequired(true)
+                .build();
+
+        Option testOption = Option.builder()
+                .id(optionId)
+                .name("Regular")
+                .price(0)
+                .isDefault(true)
+                .optionCategory(testCategory)
+                .build();
+
+        testCategory.getOptions().add(testOption);
+
+        OptionRequestDto optionDto = new OptionRequestDto("Regular", 0, true);
+        requestDto = new OptionCategoryRequestDto("사이즈", "SINGLE", true, List.of(optionDto));
+    }
+
+    @Test
+    @DisplayName("매장 접근 권한 검증 - 성공")
+    void validateStoreAccess_Success() {
+        // Given
+        String managedStoreIds = "1,2,3";
+
+        // When & Then
+        assertDoesNotThrow(() -> optionService.validateStoreAccess(storeId, managedStoreIds));
+    }
+
+    @Test
+    @DisplayName("매장 접근 권한 검증 - 실패")
+    void validateStoreAccess_Fail() {
+        // Given
+        Long wrongStoreId = 4L;
+        String managedStoreIds = "1,2,3";
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> optionService.validateStoreAccess(wrongStoreId, managedStoreIds));
+        assertEquals(ErrorCode.STORE_ACCESS_DENIED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("옵션 카테고리 생성 - 성공")
+    void createOptionCategory_Success() {
+        // Given
+        when(optionCategoryRepository.existsByStoreIdAndName(storeId, requestDto.getName())).thenReturn(false);
+        when(optionCategoryRepository.save(any(OptionCategory.class))).thenReturn(testCategory);
+
+        // When
+        Long result = optionService.createOptionCategory(storeId, requestDto);
+
+        // Then
+        assertEquals(categoryId, result);
+        verify(optionCategoryRepository).save(any(OptionCategory.class));
+    }
+
+    @Test
+    @DisplayName("옵션 카테고리 생성 - 이름 중복 실패")
+    void createOptionCategory_NameDuplicated_Fail() {
+        // Given
+        when(optionCategoryRepository.existsByStoreIdAndName(storeId, requestDto.getName())).thenReturn(true);
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> optionService.createOptionCategory(storeId, requestDto));
+        assertEquals(ErrorCode.OPTION_CATEGORY_NAME_DUPLICATED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("옵션 목록 조회 - 성공")
+    void getOptionsByStore_Success() {
+        // Given
+        when(optionCategoryRepository.findAllByStoreIdWithDetails(storeId)).thenReturn(List.of(testCategory));
+
+        // When
+        List<OptionCategoryResponseDto> result = optionService.getOptionsByStore(storeId);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("사이즈");
+        assertThat(result.get(0).getOptions()).hasSize(1);
+        verify(optionCategoryRepository).findAllByStoreIdWithDetails(storeId);
+    }
+
+    @Test
+    @DisplayName("옵션 카테고리 수정 - 성공")
+    void updateOptionCategory_Success() {
+        // Given
+        when(optionCategoryRepository.findByIdAndStoreId(categoryId, storeId)).thenReturn(Optional.of(testCategory));
+
+        // When
+        Long result = optionService.updateOptionCategory(storeId, categoryId, requestDto);
+
+        // Then
+        assertEquals(categoryId, result);
+        verify(optionCategoryRepository).findByIdAndStoreId(categoryId, storeId);
+    }
+
+    @Test
+    @DisplayName("옵션 카테고리 수정 - 찾을 수 없음")
+    void updateOptionCategory_NotFound() {
+        // Given
+        when(optionCategoryRepository.findByIdAndStoreId(categoryId, storeId)).thenReturn(Optional.empty());
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> optionService.updateOptionCategory(storeId, categoryId, requestDto));
+        assertEquals(ErrorCode.OPTION_CATEGORY_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("옵션 카테고리 삭제 - 성공")
+    void deleteOptionCategory_Success() {
+        // Given
+        when(optionCategoryRepository.findByIdAndStoreId(categoryId, storeId)).thenReturn(Optional.of(testCategory));
+        doNothing().when(optionCategoryRepository).delete(testCategory);
+
+        // When
+        optionService.deleteOptionCategory(storeId, categoryId);
+
+        // Then
+        verify(optionCategoryRepository).delete(testCategory);
+    }
+
+    @Test
+    @DisplayName("옵션 카테고리 삭제 - 찾을 수 없음")
+    void deleteOptionCategory_NotFound() {
+        // Given
+        when(optionCategoryRepository.findByIdAndStoreId(categoryId, storeId)).thenReturn(Optional.empty());
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> optionService.deleteOptionCategory(storeId, categoryId));
+        assertEquals(ErrorCode.OPTION_CATEGORY_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("개별 옵션 삭제 - 성공")
+    void deleteOption_Success() {
+        // Given
+        when(optionCategoryRepository.findByIdAndStoreId(categoryId, storeId)).thenReturn(Optional.of(testCategory));
+        doNothing().when(optionRepository).deleteById(optionId);
+
+        // When
+        optionService.deleteOption(storeId, categoryId, optionId);
+
+        // Then
+        verify(optionRepository).deleteById(optionId);
+    }
+
+    @Test
+    @DisplayName("개별 옵션 삭제 - 옵션 없음")
+    void deleteOption_OptionNotFound() {
+        // Given
+        Long wrongOptionId = 999L;
+        when(optionCategoryRepository.findByIdAndStoreId(categoryId, storeId)).thenReturn(Optional.of(testCategory));
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> optionService.deleteOption(storeId, categoryId, wrongOptionId));
+        assertEquals(ErrorCode.OPTION_NOT_FOUND, exception.getErrorCode());
+    }
+}

--- a/menu-service/src/test/java/com/samnammae/menu_service/service/OptionServiceTest.java
+++ b/menu-service/src/test/java/com/samnammae/menu_service/service/OptionServiceTest.java
@@ -188,13 +188,13 @@ class OptionServiceTest {
     void deleteOption_Success() {
         // Given
         when(optionCategoryRepository.findByIdAndStoreId(categoryId, storeId)).thenReturn(Optional.of(testCategory));
-        doNothing().when(optionRepository).deleteById(optionId);
 
         // When
         optionService.deleteOption(storeId, categoryId, optionId);
 
         // Then
-        verify(optionRepository).deleteById(optionId);
+        assertThat(testCategory.getOptions()).isEmpty();
+        verify(optionCategoryRepository).findByIdAndStoreId(categoryId, storeId);
     }
 
     @Test


### PR DESCRIPTION
### ✨ 주요 변경 사항

-   **옵션 추가 API** (`POST /api/menu/{storeId}/option`) 구현
-   **옵션 조회 API** (`GET /api/menu/{storeId}/option`) 구현
-   **옵션 수정 API** (`PUT /api/menu/{storeId}/option/{optionCategoryId}`) 구현
-   **옵션 카테고리 삭제 API** (`DELETE /api/menu/{storeId}/option/{optionCategoryId}`) 구현
-   **개별 옵션 삭제 API** (`DELETE /api/menu/{storeId}/option/{optionCategoryId}/{optionId}`) 구현
-   `Option` 및 `OptionCategory` 엔티티, 리포지토리 정의
-   옵션 CRUD 관련 **요청(Request) 및 응답(Response) DTO** 추가
-   옵션 관련 **에러 코드** 추가

### 🧪 테스트

-   **단위 테스트**: `OptionServiceTest`
-   **슬라이스 테스트**: `OptionControllerTest`

### 🔗 관련 이슈

Closes #37 