### PR TITLE
feat : 특정 메뉴 조회 API 구현

### DIFF
--- a/menu-service/src/main/java/com/samnammae/menu_service/controller/MenuController.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/controller/MenuController.java
@@ -3,6 +3,7 @@ package com.samnammae.menu_service.controller;
 import com.samnammae.common.response.ApiResponse;
 import com.samnammae.menu_service.dto.request.MenuCreateRequestDto;
 import com.samnammae.menu_service.dto.request.MenuUpdateRequestDto;
+import com.samnammae.menu_service.dto.response.MenuDetailResponseDto;
 import com.samnammae.menu_service.dto.response.MenuListResponseDto;
 import com.samnammae.menu_service.service.MenuService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -84,5 +85,15 @@ public class MenuController {
         menuService.deleteMenu(storeId, menuId);
 
         return ApiResponse.success(null);
+    }
+
+    @GetMapping("/{storeId}/{menuId}")
+    @Operation(summary = "메뉴 상세 조회", description = "특정 메뉴의 상세 정보를 조회합니다.")
+    public ApiResponse<MenuDetailResponseDto> getMenuDetail(
+            @PathVariable Long storeId,
+            @PathVariable Long menuId) {
+        MenuDetailResponseDto response = menuService.getMenuDetail(storeId, menuId);
+
+        return ApiResponse.success(response);
     }
 }

--- a/menu-service/src/main/java/com/samnammae/menu_service/domain/menu/MenuRepository.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/domain/menu/MenuRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
@@ -16,4 +17,12 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             "LEFT JOIN FETCH m.optionCategories " +
             "WHERE m.storeId = :storeId")
     List<Menu> findAllByStoreIdWithDetails(@Param("storeId") Long storeId);
+
+    // 특정 매장의 메뉴 상세 정보를 조회
+    @Query("SELECT m FROM Menu m " +
+            "LEFT JOIN FETCH m.menuCategory " +
+            "LEFT JOIN FETCH m.optionCategories oc " +
+            "LEFT JOIN FETCH oc.options " +
+            "WHERE m.id = :menuId")
+    Optional<Menu> findByIdWithDetails(@Param("menuId") Long menuId);
 }

--- a/menu-service/src/main/java/com/samnammae/menu_service/dto/response/MenuDetailResponseDto.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/dto/response/MenuDetailResponseDto.java
@@ -1,0 +1,71 @@
+package com.samnammae.menu_service.dto.response;
+
+import com.samnammae.menu_service.domain.menu.Menu;
+import com.samnammae.menu_service.domain.option.Option;
+import com.samnammae.menu_service.domain.optioncategory.OptionCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class MenuDetailResponseDto {
+    private Long menuId;
+    private String menuName;
+    private int basePrice;
+    private String description;
+    private String imageUrl;
+    private boolean isSoldOut;
+    private List<OptionCategoryDto> optionCategories; // 카테고리별로 그룹핑
+
+    @Getter
+    @Builder
+    public static class OptionCategoryDto {
+        private Long categoryId;
+        private String categoryName;
+        private List<OptionDto> options;
+    }
+
+    @Getter
+    @Builder
+    public static class OptionDto {
+        private Long optionId;
+        private String optionName;
+        private int price;
+    }
+
+    public static MenuDetailResponseDto from(Menu menu) {
+        Map<Long, List<Option>> optionsByCategory = menu.getOptionCategories().stream()
+                .collect(Collectors.toMap(
+                        OptionCategory::getId,
+                        OptionCategory::getOptions
+                ));
+
+        List<OptionCategoryDto> optionCategories = menu.getOptionCategories().stream()
+                .map(category -> OptionCategoryDto.builder()
+                        .categoryId(category.getId())
+                        .categoryName(category.getName())
+                        .options(category.getOptions().stream()
+                                .map(option -> OptionDto.builder()
+                                        .optionId(option.getId())
+                                        .optionName(option.getName())
+                                        .price(option.getPrice())
+                                        .build())
+                                .collect(Collectors.toList()))
+                        .build())
+                .collect(Collectors.toList());
+
+        return MenuDetailResponseDto.builder()
+                .menuId(menu.getId())
+                .menuName(menu.getName())
+                .basePrice(menu.getPrice())
+                .description(menu.getDescription())
+                .imageUrl(menu.getImageUrl())
+                .isSoldOut(menu.isSoldOut())
+                .optionCategories(optionCategories)
+                .build();
+    }
+}

--- a/menu-service/src/main/java/com/samnammae/menu_service/service/MenuService.java
+++ b/menu-service/src/main/java/com/samnammae/menu_service/service/MenuService.java
@@ -12,6 +12,7 @@ import com.samnammae.menu_service.domain.optioncategory.OptionCategory;
 import com.samnammae.menu_service.domain.optioncategory.OptionCategoryRepository;
 import com.samnammae.menu_service.dto.request.MenuCreateRequestDto;
 import com.samnammae.menu_service.dto.request.MenuUpdateRequestDto;
+import com.samnammae.menu_service.dto.response.MenuDetailResponseDto;
 import com.samnammae.menu_service.dto.response.MenuListResponseDto;
 import com.samnammae.menu_service.dto.response.MenuResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -143,6 +144,18 @@ public class MenuService {
         }
 
         menuRepository.delete(menu);
+    }
+
+    public MenuDetailResponseDto getMenuDetail(Long storeId, Long menuId) {
+        Menu menu = menuRepository.findByIdWithDetails(menuId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+        // 매장 소유권 확인
+        if (!menu.getStoreId().equals(storeId)) {
+            throw new CustomException(ErrorCode.MENU_STORE_MISMATCH);
+        }
+
+        return MenuDetailResponseDto.from(menu);
     }
 
     // JSON 문자열을 파싱하여 OptionCategory Set을 반환하는 헬퍼 메서드

--- a/menu-service/src/test/java/com/samnammae/menu_service/controller/MenuControllerTest.java
+++ b/menu-service/src/test/java/com/samnammae/menu_service/controller/MenuControllerTest.java
@@ -5,6 +5,7 @@ import com.samnammae.common.exception.CustomException;
 import com.samnammae.common.exception.ErrorCode;
 import com.samnammae.menu_service.dto.request.MenuCreateRequestDto;
 import com.samnammae.menu_service.dto.request.MenuUpdateRequestDto;
+import com.samnammae.menu_service.dto.response.MenuDetailResponseDto;
 import com.samnammae.menu_service.dto.response.MenuListResponseDto;
 import com.samnammae.menu_service.dto.response.MenuResponseDto;
 import com.samnammae.menu_service.service.MenuService;
@@ -16,7 +17,9 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -25,7 +28,8 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MenuController.class)
 class MenuControllerTest {
@@ -46,23 +50,24 @@ class MenuControllerTest {
         Long storeId = 1L;
         String managedStoreIds = "1,2,3";
         MenuCreateRequestDto requestDto = new MenuCreateRequestDto(
-                "치킨버거", 8000, "맛있는 치킨버거", 1L, "1,2", false);
+                "치킨버거", 8000, "맛있는 치킨버거", 1L, "[1,2]", false);
         Long menuId = 1L;
 
         MockMultipartFile image = new MockMultipartFile(
-                "image", "test.jpg", "image/jpeg", "test content".getBytes());
-        MockMultipartFile request = new MockMultipartFile(
-                "request", "", "application/json", objectMapper.writeValueAsString(requestDto).getBytes());
+                "image", "test.jpg", MediaType.IMAGE_JPEG_VALUE, "test content".getBytes());
+        MockMultipartFile requestFile = new MockMultipartFile(
+                "request", "request.json", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(requestDto).getBytes(StandardCharsets.UTF_8));
 
+        doNothing().when(menuService).validateStoreAccess(storeId, managedStoreIds);
         when(menuService.createMenu(eq(storeId), any(MenuCreateRequestDto.class), any()))
                 .thenReturn(menuId);
 
         // When & Then
         mockMvc.perform(multipart("/api/menu/{storeId}", storeId)
-                        .file(request)
+                        .file(requestFile)
                         .file(image)
-                        .header("X-MANAGED-STORE-IDS", managedStoreIds)
-                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").value(1));
@@ -78,20 +83,21 @@ class MenuControllerTest {
         Long storeId = 1L;
         String managedStoreIds = "1,2,3";
         MenuCreateRequestDto requestDto = new MenuCreateRequestDto(
-                "치킨버거", 8000, "맛있는 치킨버거", 1L, "1,2", false);
+                "치킨버거", 8000, "맛있는 치킨버거", 1L, "[1,2]", false);
         Long menuId = 1L;
 
-        MockMultipartFile request = new MockMultipartFile(
-                "request", "", "application/json", objectMapper.writeValueAsString(requestDto).getBytes());
+        MockMultipartFile requestFile = new MockMultipartFile(
+                "request", "request.json", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(requestDto).getBytes(StandardCharsets.UTF_8));
 
+        doNothing().when(menuService).validateStoreAccess(storeId, managedStoreIds);
         when(menuService.createMenu(eq(storeId), any(MenuCreateRequestDto.class), isNull()))
                 .thenReturn(menuId);
 
         // When & Then
         mockMvc.perform(multipart("/api/menu/{storeId}", storeId)
-                        .file(request)
-                        .header("X-MANAGED-STORE-IDS", managedStoreIds)
-                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                        .file(requestFile)
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").value(1));
@@ -107,19 +113,19 @@ class MenuControllerTest {
         Long storeId = 1L;
         String managedStoreIds = "2,3,4";
         MenuCreateRequestDto requestDto = new MenuCreateRequestDto(
-                "치킨버거", 8000, "맛있는 치킨버거", 1L, "1,2", false);
+                "치킨버거", 8000, "맛있는 치킨버거", 1L, "[1,2]", false);
 
-        MockMultipartFile request = new MockMultipartFile(
-                "request", "", "application/json", objectMapper.writeValueAsString(requestDto).getBytes());
+        MockMultipartFile requestFile = new MockMultipartFile(
+                "request", "request.json", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(requestDto).getBytes(StandardCharsets.UTF_8));
 
         doThrow(new CustomException(ErrorCode.STORE_ACCESS_DENIED))
                 .when(menuService).validateStoreAccess(storeId, managedStoreIds);
 
         // When & Then
         mockMvc.perform(multipart("/api/menu/{storeId}", storeId)
-                        .file(request)
-                        .header("X-MANAGED-STORE-IDS", managedStoreIds)
-                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                        .file(requestFile)
+                        .header("X-MANAGED-STORE-IDS", managedStoreIds))
                 .andExpect(status().isForbidden());
 
         verify(menuService).validateStoreAccess(storeId, managedStoreIds);
@@ -142,6 +148,7 @@ class MenuControllerTest {
 
         MenuListResponseDto response = new MenuListResponseDto(categories, menusByCategory);
 
+        doNothing().when(menuService).validateStoreAccess(storeId, managedStoreIds);
         when(menuService.getMenusByStore(storeId)).thenReturn(response);
 
         // When & Then
@@ -150,9 +157,7 @@ class MenuControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.categories").isArray())
-                .andExpect(jsonPath("$.data.categories.length()").value(2))
-                .andExpect(jsonPath("$.data.categories[0]").value("메인 메뉴"))
-                .andExpect(jsonPath("$.data.menusByCategory['메인 메뉴'][0].name").value("치킨버거"));
+                .andExpect(jsonPath("$.data.categories.length()").value(2));
 
         verify(menuService).validateStoreAccess(storeId, managedStoreIds);
         verify(menuService).getMenusByStore(storeId);
@@ -166,25 +171,26 @@ class MenuControllerTest {
         Long menuId = 1L;
         String managedStoreIds = "1,2,3";
         MenuUpdateRequestDto requestDto = new MenuUpdateRequestDto(
-                "수정된 치킨버거", 9000, "더 맛있는 치킨버거", 1L, "1,2", false);
+                "수정된 치킨버거", 9000, "더 맛있는 치킨버거", 1L, "[1,2]", false);
 
         MockMultipartFile image = new MockMultipartFile(
-                "image", "updated.jpg", "image/jpeg", "updated content".getBytes());
-        MockMultipartFile request = new MockMultipartFile(
-                "request", "", "application/json", objectMapper.writeValueAsString(requestDto).getBytes());
+                "image", "updated.jpg", MediaType.IMAGE_JPEG_VALUE, "updated content".getBytes());
+        MockMultipartFile requestFile = new MockMultipartFile(
+                "request", "request.json", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(requestDto).getBytes(StandardCharsets.UTF_8));
 
+        doNothing().when(menuService).validateStoreAccess(storeId, managedStoreIds);
         when(menuService.updateMenu(eq(storeId), eq(menuId), any(MenuUpdateRequestDto.class), any()))
                 .thenReturn(menuId);
 
         // When & Then
-        mockMvc.perform(multipart("/api/menu/{storeId}/{menuId}", storeId, menuId)
-                        .file(request)
+        mockMvc.perform(MockMvcRequestBuilders.multipart("/api/menu/{storeId}/{menuId}", storeId, menuId)
+                        .file(requestFile)
                         .file(image)
                         .header("X-MANAGED-STORE-IDS", managedStoreIds)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(requestPostProcessor -> {
-                            requestPostProcessor.setMethod("PUT");
-                            return requestPostProcessor;
+                        .with(httpRequest -> {
+                            httpRequest.setMethod("PUT");
+                            return httpRequest;
                         }))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -202,22 +208,23 @@ class MenuControllerTest {
         Long menuId = 999L;
         String managedStoreIds = "1,2,3";
         MenuUpdateRequestDto requestDto = new MenuUpdateRequestDto(
-                "수정된 치킨버거", 9000, "더 맛있는 치킨버거", 1L, "1,2", false);
+                "수정된 치킨버거", 9000, "더 맛있는 치킨버거", 1L, "[1,2]", false);
 
-        MockMultipartFile request = new MockMultipartFile(
-                "request", "", "application/json", objectMapper.writeValueAsString(requestDto).getBytes());
+        MockMultipartFile requestFile = new MockMultipartFile(
+                "request", "request.json", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(requestDto).getBytes(StandardCharsets.UTF_8));
 
+        doNothing().when(menuService).validateStoreAccess(storeId, managedStoreIds);
         when(menuService.updateMenu(eq(storeId), eq(menuId), any(MenuUpdateRequestDto.class), any()))
                 .thenThrow(new CustomException(ErrorCode.MENU_NOT_FOUND));
 
         // When & Then
-        mockMvc.perform(multipart("/api/menu/{storeId}/{menuId}", storeId, menuId)
-                        .file(request)
+        mockMvc.perform(MockMvcRequestBuilders.multipart("/api/menu/{storeId}/{menuId}", storeId, menuId)
+                        .file(requestFile)
                         .header("X-MANAGED-STORE-IDS", managedStoreIds)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(requestPostProcessor -> {
-                            requestPostProcessor.setMethod("PUT");
-                            return requestPostProcessor;
+                        .with(httpRequest -> {
+                            httpRequest.setMethod("PUT");
+                            return httpRequest;
                         }))
                 .andExpect(status().isNotFound());
 
@@ -233,12 +240,14 @@ class MenuControllerTest {
         Long menuId = 1L;
         String managedStoreIds = "1,2,3";
 
+        doNothing().when(menuService).validateStoreAccess(storeId, managedStoreIds);
+        doNothing().when(menuService).deleteMenu(storeId, menuId);
+
         // When & Then
         mockMvc.perform(delete("/api/menu/{storeId}/{menuId}", storeId, menuId)
                         .header("X-MANAGED-STORE-IDS", managedStoreIds))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data").isEmpty());
+                .andExpect(jsonPath("$.success").value(true));
 
         verify(menuService).validateStoreAccess(storeId, managedStoreIds);
         verify(menuService).deleteMenu(storeId, menuId);
@@ -252,6 +261,7 @@ class MenuControllerTest {
         Long menuId = 999L;
         String managedStoreIds = "1,2,3";
 
+        doNothing().when(menuService).validateStoreAccess(storeId, managedStoreIds);
         doThrow(new CustomException(ErrorCode.MENU_NOT_FOUND))
                 .when(menuService).deleteMenu(storeId, menuId);
 
@@ -265,20 +275,97 @@ class MenuControllerTest {
     }
 
     @Test
+    @DisplayName("메뉴 상세 조회 - 성공")
+    void getMenuDetail_Success() throws Exception {
+        // Given
+        Long storeId = 1L;
+        Long menuId = 1L;
+
+        MenuDetailResponseDto.OptionDto optionDto = MenuDetailResponseDto.OptionDto.builder()
+                .optionId(1L)
+                .optionName("라지")
+                .price(1000)
+                .build();
+
+        MenuDetailResponseDto.OptionCategoryDto categoryDto = MenuDetailResponseDto.OptionCategoryDto.builder()
+                .categoryId(1L)
+                .categoryName("사이즈")
+                .options(Arrays.asList(optionDto))
+                .build();
+
+        MenuDetailResponseDto response = MenuDetailResponseDto.builder()
+                .menuId(1L)
+                .menuName("치킨버거")
+                .basePrice(8000)
+                .description("맛있는 치킨버거")
+                .imageUrl("https://example.com/image.jpg")
+                .isSoldOut(false)
+                .optionCategories(Arrays.asList(categoryDto))
+                .build();
+
+        when(menuService.getMenuDetail(storeId, menuId)).thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(get("/api/menu/{storeId}/{menuId}", storeId, menuId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.menuId").value(1))
+                .andExpect(jsonPath("$.data.menuName").value("치킨버거"))
+                .andExpect(jsonPath("$.data.basePrice").value(8000))
+                .andExpect(jsonPath("$.data.soldOut").value(false));
+
+        verify(menuService).getMenuDetail(storeId, menuId);
+    }
+
+    @Test
+    @DisplayName("메뉴 상세 조회 - 메뉴 없음")
+    void getMenuDetail_MenuNotFound() throws Exception {
+        // Given
+        Long storeId = 1L;
+        Long menuId = 999L;
+
+        when(menuService.getMenuDetail(storeId, menuId))
+                .thenThrow(new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+        // When & Then
+        mockMvc.perform(get("/api/menu/{storeId}/{menuId}", storeId, menuId))
+                .andExpect(status().isNotFound());
+
+        verify(menuService).getMenuDetail(storeId, menuId);
+    }
+
+    @Test
+    @DisplayName("메뉴 상세 조회 - 매장 불일치")
+    void getMenuDetail_StoreMismatch() throws Exception {
+        // Given
+        Long storeId = 1L;
+        Long menuId = 1L;
+
+        when(menuService.getMenuDetail(storeId, menuId))
+                .thenThrow(new CustomException(ErrorCode.MENU_STORE_MISMATCH));
+
+        // When & Then
+        mockMvc.perform(get("/api/menu/{storeId}/{menuId}", storeId, menuId))
+                .andExpect(status().isForbidden());
+
+        verify(menuService).getMenuDetail(storeId, menuId);
+    }
+
+    @Test
     @DisplayName("헤더 누락 - 매장 ID 헤더 없음")
     void missingHeader() throws Exception {
         // Given
         Long storeId = 1L;
         MenuCreateRequestDto requestDto = new MenuCreateRequestDto(
-                "치킨버거", 8000, "맛있는 치킨버거", 1L, "1,2", false);
+                "치킨버거", 8000, "맛있는 치킨버거", 1L, "[1,2]", false);
 
-        MockMultipartFile request = new MockMultipartFile(
-                "request", "", "application/json", objectMapper.writeValueAsString(requestDto).getBytes());
+        MockMultipartFile requestFile = new MockMultipartFile(
+                "request", "request.json", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(requestDto).getBytes(StandardCharsets.UTF_8));
 
         // When & Then
         mockMvc.perform(multipart("/api/menu/{storeId}", storeId)
-                        .file(request)
-                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                        .file(requestFile))
                 .andExpect(status().isBadRequest());
 
         verify(menuService, never()).validateStoreAccess(anyLong(), anyString());


### PR DESCRIPTION
### ✨ 주요 변경 사항
- **메뉴 상세 조회 API** (`GET /api/menu/{storeId}/{menuId}`) 구현
- `MenuRepository`에 `findByIdWithDetails` 쿼리 메서드 추가 (옵션 카테고리 및 옵션 포함 조회)
- **메뉴 상세 응답 DTO** (`MenuDetailResponseDto`) 추가
- `MenuService`에 `getMenuDetail` 메서드 구현

### 🧪 테스트
- **단위 테스트**: `MenuServiceTest`
- **슬라이스 테스트**: `MenuControllerTest`

### 🔗 관련 이슈
#39 