### PR TITLE
feat : Gemini 연동 및 주문 서비스 호출 로직 구현

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -43,6 +43,14 @@ spring:
                 - Path=/api/order/**
               filters:
                 - AuthorizationHeader
+
+            # Chatbot 서비스 라우팅 규칙
+            - id: chatbot-service-route
+              uri: lb://chatbot-service # 로드 밸런싱을 통해 chatbot-service
+              predicates:
+                - Path=/api/chatbot/**
+              filters:
+                  - AuthorizationHeader
           default-filters:
             - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials
           globalcors:

--- a/chatbot-service/Dockerfile
+++ b/chatbot-service/Dockerfile
@@ -1,0 +1,12 @@
+# Java 17 이미지 기반 (원하는 버전에 맞게 조정 가능)
+FROM openjdk:17-jdk-slim
+
+# JAR 파일 복사
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+# 포트 오픈
+EXPOSE 8085
+
+# 실행 명령
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/client/GeminiClient.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/client/GeminiClient.java
@@ -1,0 +1,18 @@
+package com.samnammae.chatbot_service.client;
+
+import com.samnammae.chatbot_service.config.GeminiClientConfig;
+import com.samnammae.chatbot_service.dto.request.GeminiRequest;
+import com.samnammae.chatbot_service.dto.response.GeminiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "gemini-api",
+        url = "https://generativelanguage.googleapis.com",
+        configuration = GeminiClientConfig.class)
+public interface GeminiClient {
+
+    @PostMapping(value = "/v1beta/models/gemini-1.5-flash-latest:generateContent",
+            headers = {"Content-Type=application/json"})
+    GeminiResponse call(@RequestBody GeminiRequest request);
+}

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/client/MenuServiceClient.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/client/MenuServiceClient.java
@@ -1,0 +1,16 @@
+package com.samnammae.chatbot_service.client;
+
+import com.samnammae.chatbot_service.dto.response.MenuResponseDto;
+import com.samnammae.common.response.ApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "menu-service")
+public interface MenuServiceClient {
+
+    @GetMapping("/api/menu/{storeId}")
+    ApiResponse<MenuResponseDto> getMenusByStore(@PathVariable Long storeId,
+                                                 @RequestHeader("X-MANAGED-STORE-IDS") String managedStoreIds); // 반환 타입 수정
+}

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/client/OrderServiceClient.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/client/OrderServiceClient.java
@@ -1,0 +1,15 @@
+package com.samnammae.chatbot_service.client;
+
+import com.samnammae.chatbot_service.dto.request.OrderRequestDto;
+import com.samnammae.chatbot_service.dto.response.OrderResponseDto;
+import com.samnammae.common.response.ApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "order-service")
+public interface OrderServiceClient {
+
+    @PostMapping("/api/order")
+    ApiResponse<OrderResponseDto> placeOrder(@RequestBody OrderRequestDto request);
+}

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/config/GeminiClientConfig.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/config/GeminiClientConfig.java
@@ -1,0 +1,16 @@
+package com.samnammae.chatbot_service.config;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+public class GeminiClientConfig {
+
+    @Value("${GEMINI_API_KEY}")
+    private String apiKey;
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> requestTemplate.query("key", apiKey);
+    }
+}

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/controller/ChatController.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/controller/ChatController.java
@@ -10,14 +10,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/chat")
+@RequestMapping("/api/chatbot")
 @Tag(name = "Chatbot", description = "챗봇 관련 API")
 @RequiredArgsConstructor
 public class ChatController {
 
     private final ChatService chatService;
 
-    @PostMapping("/api/chatbot/{storeId}/chat")
+    @PostMapping("/{storeId}")
     public ApiResponse<ChatResponse> handleChat(
             @PathVariable Long storeId,
             @RequestBody ChatRequest request,
@@ -26,7 +26,7 @@ public class ChatController {
         //  매장 권한 검증
         chatService.validateStoreAccess(storeId, managedStoreIds);
 
-        ChatResponse response = chatService.processChat(request.getSessionId(), request.getMessage());
+        ChatResponse response = chatService.processChat(storeId, request.getSessionId(), request.getMessage(), managedStoreIds);
 
         return ApiResponse.success(response);
     }

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/dto/request/GeminiRequest.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/dto/request/GeminiRequest.java
@@ -1,0 +1,35 @@
+package com.samnammae.chatbot_service.dto.request;
+
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+public class GeminiRequest {
+
+    private final List<Content> contents;
+
+    // 프롬프트 문자열 하나만으로 간단히 요청 객체를 생성하는 생성자
+    public GeminiRequest(String prompt) {
+        this.contents = Collections.singletonList(new Content(Collections.singletonList(new Part(prompt))));
+    }
+
+    @Getter
+    private static class Content {
+        private final List<Part> parts;
+
+        public Content(List<Part> parts) {
+            this.parts = parts;
+        }
+    }
+
+    @Getter
+    private static class Part {
+        private final String text;
+
+        public Part(String text) {
+            this.text = text;
+        }
+    }
+}

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/dto/request/OrderRequestDto.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/dto/request/OrderRequestDto.java
@@ -1,0 +1,35 @@
+package com.samnammae.chatbot_service.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderRequestDto {
+
+    private Long storeId;
+    private String storeName;
+    private String orderType;
+    private String paymentMethod;
+    private List<OrderItemDto> items;
+    private int totalAmount;
+    private int totalItems;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OrderItemDto {
+        private Long menuId;
+        private String menuName;
+        private int basePrice;
+        private Map<Long, List<Long>> selectedOptions;
+        private int optionPrice;
+        private int quantity;
+        private int totalPrice;
+    }
+}

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/dto/response/GeminiResponse.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/dto/response/GeminiResponse.java
@@ -1,0 +1,51 @@
+package com.samnammae.chatbot_service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true) // 응답의 모든 필드를 매핑하지 않을 것이므로 이 어노테이션 추가
+public class GeminiResponse {
+
+    private List<Candidate> candidates;
+
+    /**
+     * 복잡한 응답 객체에서 실제 텍스트 답변만 쉽게 추출하는 편의 메소드
+     * @return AI가 생성한 텍스트 응답
+     */
+    public String extractText() {
+        try {
+            if (candidates != null && !candidates.isEmpty()) {
+                return candidates.get(0).getContent().getParts().get(0).getText();
+            }
+        } catch (Exception e) {
+            // 로깅을 추가하면 더 좋습니다. e.g., log.error("Failed to parse Gemini response", e);
+        }
+        return "죄송합니다. 답변을 생성하는 데 문제가 발생했습니다.";
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Candidate {
+        private Content content;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Content {
+        private List<Part> parts;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Part {
+        private String text;
+    }
+}

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/dto/response/MenuResponseDto.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/dto/response/MenuResponseDto.java
@@ -1,0 +1,26 @@
+package com.samnammae.chatbot_service.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+public class MenuResponseDto {
+    private List<String> categories;
+    private Map<String, List<MenuItemDto>> menusByCategory;
+
+    @Getter
+    @NoArgsConstructor
+    public static class MenuItemDto {
+        private String id;
+        private String name;
+        private int price;
+        private String description;
+        private String image;
+        private List<String> optionCategories;
+        private boolean isSoldOut;
+    }
+}

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/dto/response/OrderResponseDto.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/dto/response/OrderResponseDto.java
@@ -1,0 +1,13 @@
+package com.samnammae.chatbot_service.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderResponseDto {
+    private String orderId;
+    private String orderNumber;
+}

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/service/ChatService.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/service/ChatService.java
@@ -1,23 +1,39 @@
 package com.samnammae.chatbot_service.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.samnammae.chatbot_service.client.GeminiClient;
+import com.samnammae.chatbot_service.client.OrderServiceClient;
 import com.samnammae.chatbot_service.domain.conversation.Conversation;
 import com.samnammae.chatbot_service.domain.conversation.ConversationRepository;
 import com.samnammae.chatbot_service.domain.message.Message;
+import com.samnammae.chatbot_service.dto.request.GeminiRequest;
+import com.samnammae.chatbot_service.dto.request.OrderRequestDto;
 import com.samnammae.chatbot_service.dto.response.ChatResponse;
+import com.samnammae.chatbot_service.dto.response.GeminiResponse;
 import com.samnammae.common.exception.CustomException;
 import com.samnammae.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatService {
 
     private final ConversationRepository conversationRepository;
+    private final GeminiPromptService geminiPromptService;
+    private final GeminiClient geminiClient;
+    private final OrderServiceClient orderServiceClient;
+    private final ObjectMapper objectMapper;
 
     // 매장 권한 검증 메서드
     public void validateStoreAccess(Long storeId, String managedStoreIds) {
@@ -31,23 +47,91 @@ public class ChatService {
     }
 
     @Transactional
-    public ChatResponse processChat(String sessionId, String userMessage) {
+    public ChatResponse processChat(Long storeId, String sessionId, String userMessage, String managedStoreIds) {
+        log.info("Processing chat for storeId: {}, sessionId: {}, userMessage: {}", storeId, sessionId, userMessage);
 
-        // 1. sessionId로 기존 대화 조회 또는 새로 생성
+        // 1. 대화 기록 조회 또는 생성
         Conversation conversation = conversationRepository.findBySessionId(sessionId)
                 .orElseGet(() -> new Conversation(sessionId));
 
-        // 2. 사용자의 메시지를 대화 기록에 추가
+        // 2. 현재 사용자 메시지를 대화 기록에 추가
         conversation.addMessage(Message.of("USER", userMessage));
 
-        // 3. (핵심) 임시 AI 고정 응답 생성 및 기록에 추가
-        String aiResponseContent = "요청을 확인했습니다. AI 연동은 다음 이슈에서 진행될 예정입니다.";
-        conversation.addMessage(Message.of("AI", aiResponseContent));
+        // 3. Gemini에 보낼 프롬프트 생성
+        String prompt = geminiPromptService.createPrompt(storeId, conversation, managedStoreIds);
+        log.debug("Generated prompt: {}", prompt);
 
-        // 4. 변경된 대화 내용을 MongoDB에 저장 (update or insert)
+        // 4. Gemini API 호출하여 AI의 원본 응답 받기
+        GeminiResponse geminiResponse = geminiClient.call(new GeminiRequest(prompt));
+        String aiRawResponse = geminiResponse.extractText();
+        log.info("Gemini raw response: {}", aiRawResponse);
+
+        // 5. AI 응답 분석 후 최종 메시지 결정
+        String finalAiMessage;
+        Optional<OrderRequestDto> orderRequestOpt = parseOrderAction(aiRawResponse);
+
+        if (orderRequestOpt.isPresent()) {
+            log.info("Order action detected, processing order...");
+            // 5-1. 주문 요청인 경우: Order Service 호출
+            OrderRequestDto orderRequest = orderRequestOpt.get();
+            log.info("Order request details: {}", orderRequest);
+
+            try {
+                var orderApiResponse = orderServiceClient.placeOrder(orderRequest);
+                log.info("Order service response: {}", orderApiResponse);
+                finalAiMessage = "주문이 완료되었습니다. 주문번호는 " + orderApiResponse.getData().getOrderNumber() + "입니다.";
+            } catch (Exception e) {
+                log.error("Failed to place order", e);
+                finalAiMessage = "주문 처리 중 오류가 발생했습니다. 다시 시도해 주세요.";
+            }
+        } else {
+            log.info("Regular conversation, using Gemini response as is");
+            // 5-2. 일반 대화인 경우: Gemini 응답 그대로 사용
+            finalAiMessage = aiRawResponse;
+        }
+
+        // 6. 최종 AI 응답을 대화 기록에 저장
+        conversation.addMessage(Message.of("AI", finalAiMessage));
         conversationRepository.save(conversation);
 
-        // 5. API 명세에 맞는 최종 응답 생성
-        return new ChatResponse(conversation.getSessionId(), aiResponseContent);
+        log.info("Final AI message: {}", finalAiMessage);
+        // 7. 클라이언트에 전달할 최종 응답 생성
+        return new ChatResponse(conversation.getSessionId(), finalAiMessage);
+    }
+
+    // Gemini가 반환한 텍스트가 주문을 위한 JSON 액션인지 파싱하는 헬퍼 메소드
+    private Optional<OrderRequestDto> parseOrderAction(String textResponse) {
+        log.debug("Parsing order action from response: {}", textResponse);
+
+        // markdown 코드 블록 제거
+        String cleanedResponse = textResponse
+                .replaceAll("```json\\s*", "")  // ```json 제거
+                .replaceAll("```\\s*", "")      // ``` 제거
+                .trim();
+
+        log.debug("Cleaned response for JSON parsing: {}", cleanedResponse);
+
+        try {
+            GeminiOrderActionDto actionDto = objectMapper.readValue(cleanedResponse, GeminiOrderActionDto.class);
+            log.debug("Parsed action DTO: action={}, order_details={}", actionDto.getAction(), actionDto.getOrder_details());
+
+            if ("PLACE_ORDER".equals(actionDto.getAction()) && actionDto.getOrder_details() != null) {
+                log.info("Valid order action found");
+                return Optional.of(actionDto.getOrder_details());
+            } else {
+                log.debug("Not a valid order action: action={}", actionDto.getAction());
+            }
+        } catch (JsonProcessingException e) {
+            log.debug("Failed to parse as JSON order action, treating as regular text: {}", e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    // Gemini의 주문 액션 응답을 파싱하기 위한 내부 DTO
+    @Getter
+    @NoArgsConstructor
+    private static class GeminiOrderActionDto {
+        private String action;
+        private OrderRequestDto order_details;
     }
 }

--- a/chatbot-service/src/main/java/com/samnammae/chatbot_service/service/GeminiPromptService.java
+++ b/chatbot-service/src/main/java/com/samnammae/chatbot_service/service/GeminiPromptService.java
@@ -1,0 +1,148 @@
+package com.samnammae.chatbot_service.service;
+
+import com.samnammae.chatbot_service.client.MenuServiceClient;
+import com.samnammae.chatbot_service.domain.conversation.Conversation;
+import com.samnammae.chatbot_service.domain.message.Message;
+import com.samnammae.chatbot_service.dto.response.MenuResponseDto;
+import com.samnammae.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GeminiPromptService {
+
+    private final MenuServiceClient menuServiceClient;
+
+    public String createPrompt(Long storeId, Conversation conversation, String managedStoreIds) {
+        log.info("Creating prompt for storeId: {}", storeId);
+
+        String systemPrompt = createSystemPrompt();
+        String menuData = fetchAndFormatMenuData(storeId, managedStoreIds);
+        String history = formatHistory(conversation.getMessages());
+
+        StringBuilder promptBuilder = new StringBuilder();
+        promptBuilder.append(systemPrompt);
+        promptBuilder.append("\n\n# MENU DATA\n");
+        promptBuilder.append(menuData);
+        promptBuilder.append("\n\n# CONVERSATION HISTORY & CURRENT QUESTION\n");
+        promptBuilder.append(history);
+
+        log.debug("Generated prompt length: {}", promptBuilder.length());
+        return promptBuilder.toString();
+    }
+
+    private String createSystemPrompt() {
+        return """
+            # ROLE & VERY IMPORTANT RULE
+            You are a helpful kiosk ordering assistant for 'inclukiosk'.
+            Your primary goal is to help users build an order based on the provided MENU DATA.
+
+            When the user finalizes their order, you MUST follow this rule:
+            1. Your ENTIRE response MUST be ONLY a JSON object.
+            2. Do NOT add any other text, explanations, or markdown formatting.
+            3. The JSON object MUST match this exact structure:
+               {
+                 "action": "PLACE_ORDER",
+                 "order_details": {
+                   "storeId": 1,
+                   "storeName": "현재 매장 이름",
+                   "orderType": "TAKEOUT",
+                   "paymentMethod": "CARD",
+                   "items": [
+                     {
+                       "menuId": 101,
+                       "menuName": "아메리카노",
+                       "basePrice": 4500,
+                       "selectedOptions": { "1": [10] },
+                       "optionPrice": 500,
+                       "quantity": 1,
+                       "totalPrice": 5000
+                     }
+                   ],
+                   "totalAmount": 5000,
+                   "totalItems": 1
+                 }
+               }
+            
+            For all other conversation that is not a final order confirmation, respond naturally in Korean.
+            """;
+    }
+
+    private String fetchAndFormatMenuData(Long storeId, String managedStoreIds) {
+        log.info("Fetching menu data for storeId: {}", storeId);
+
+        try {
+            log.debug("Calling menuServiceClient.getMenusByStore with storeId: {}", storeId);
+            ApiResponse<MenuResponseDto> response = menuServiceClient.getMenusByStore(storeId, managedStoreIds);
+
+            log.info("MenuServiceClient response received. Status: {}, HasData: {}",
+                    response != null ? "SUCCESS" : "NULL",
+                    response != null && response.getData() != null);
+
+            if (response == null) {
+                log.error("MenuServiceClient returned null response");
+                return "메뉴 정보를 불러오는 데 실패했습니다. (응답이 null)";
+            }
+
+            MenuResponseDto menuData = response.getData();
+
+            if (menuData == null) {
+                log.error("MenuServiceClient returned null data in response");
+                return "메뉴 정보가 없습니다. (데이터가 null)";
+            }
+
+            log.info("Menu data received. Categories count: {}",
+                    menuData.getMenusByCategory() != null ? menuData.getMenusByCategory().size() : 0);
+
+            if (menuData.getMenusByCategory().isEmpty()) {
+                log.warn("Menu data is empty for storeId: {}", storeId);
+                return "메뉴 정보가 없습니다. (카테고리가 비어있음)";
+            }
+
+            StringBuilder sb = new StringBuilder();
+            int totalMenuItems = 0;
+
+            for (Map.Entry<String, List<MenuResponseDto.MenuItemDto>> entry : menuData.getMenusByCategory().entrySet()) {
+                String category = entry.getKey();
+                List<MenuResponseDto.MenuItemDto> items = entry.getValue();
+
+                log.debug("Processing category: {}, items count: {}", category, items.size());
+                totalMenuItems += items.size();
+
+                sb.append("## ").append(category).append("\n");
+                for (MenuResponseDto.MenuItemDto item : items) {
+                    sb.append("- 이름: ").append(item.getName())
+                            .append(", 가격: ").append(item.getPrice()).append("원")
+                            .append(", 설명: ").append(item.getDescription()).append("\n");
+                }
+            }
+
+            log.info("Menu data formatting completed. Total items: {}, formatted length: {}",
+                    totalMenuItems, sb.length());
+
+            return sb.toString();
+
+        } catch (Exception e) {
+            log.error("Failed to fetch menu data for storeId: {}. Error: {}", storeId, e.getMessage(), e);
+            return "메뉴 정보를 불러오는 데 실패했습니다. (" + e.getMessage() + ")";
+        }
+    }
+
+    private String formatHistory(List<Message> messages) {
+        log.debug("Formatting conversation history. Messages count: {}", messages.size());
+
+        StringBuilder sb = new StringBuilder();
+        for (Message message : messages) {
+            sb.append(message.getRole()).append(": ").append(message.getContent()).append("\n");
+        }
+
+        log.debug("History formatting completed. Length: {}", sb.length());
+        return sb.toString();
+    }
+}

--- a/chatbot-service/src/main/resources/application.yml
+++ b/chatbot-service/src/main/resources/application.yml
@@ -30,3 +30,7 @@ eureka:
       defaultZone: http://localhost:8761/eureka/
   instance:
     instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+
+logging:
+  level:
+    com.samnammae.chatbot_service: DEBUG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,20 @@ services:
     networks:
       - my-msa-network
 
+  # 1.5. Chatbot Service용 MongoDB
+  mongodb-chatbot:
+    image: mongo:latest
+    ports:
+      - "27018:27017" # 포트 충돌 방지를 위해 호스트 포트를 27018로 변경
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${CHATBOT_MONGO_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${CHATBOT_MONGO_PASSWORD}
+      MONGO_INITDB_DATABASE: ${CHATBOT_MONGO_DATABASE}
+    volumes:
+      - mongodb-data-chatbot:/data/db
+    networks:
+      - my-msa-network
+
   # --- 2. 코어 MSA 인프라 서비스 ---
 
   # 2.1. 유레카 서버 (Service Discovery)
@@ -172,30 +186,31 @@ services:
       - my-msa-network
 
   # 3.5. Chatbot Service (클라이언트 챗봇)
-#  chatbot-service:
-#    build:
-#      context: ./chatbot-service
-#      dockerfile: Dockerfile
-#    ports:
-#      - "8085:8085" # Chatbot Service 포트 (다른 서비스와 중복되지 않게)
-#    environment:
-#      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://eureka-server:8761/eureka
-#      # 챗봇 서비스가 다른 서비스의 API를 호출해야 한다면 여기에 추가 설정이 필요할 수 있습니다.
-#      # 예: MENU_SERVICE_URL=http://menu-service:8084/api/menu
-#    depends_on:
-#      - eureka-server
-#      # 챗봇 서비스가 메뉴, 매장 정보 등을 조회하므로 해당 서비스들에 대한 의존성도 고려할 수 있음
-#      # - menu-service
-#      # - admin-service
-#    networks:
-#      - my-msa-network
+  chatbot-service:
+    build:
+      context: ./chatbot-service
+      dockerfile: Dockerfile
+    ports:
+      - "8085:8085"
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://eureka-server:8761/eureka
+      - SPRING_DATA_MONGODB_URI=mongodb://${CHATBOT_MONGO_USERNAME}:${CHATBOT_MONGO_PASSWORD}@mongodb-chatbot:27017/${CHATBOT_MONGO_DATABASE}?authSource=admin
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+    depends_on:
+      - eureka-server
+      - mongodb-chatbot # 자신의 데이터베이스에 의존
+      - menu-service    # RAG를 위해 메뉴 서비스가 먼저 실행되어야 함
+      - order-service   # 주문을 위해 오더 서비스가 먼저 실행되어야 함
+    networks:
+      - my-msa-network
 
 # --- 4. 데이터 영속성을 위한 볼륨 정의 ---
 volumes:
   mysql-data-auth:
   mysql-data-admin:
   mysql-data-menu:
-  mongodb-data-order: # MongoDB용 볼륨 추가
+  mongodb-data-order:
+  mongodb-data-chatbot:
 
 # --- 5. 모든 서비스가 통신할 수 있는 사용자 정의 네트워크 ---
 networks:


### PR DESCRIPTION
## ✨ 주요 변경 사항

  - **Gemini API 연동 및 핵심 로직 구현**
      - `ChatService`의 임시 응답 로직을 실제 Gemini API를 호출하는 로직으로 대체
      - `GeminiPromptService`를 구현하여, `MenuServiceClient`를 통해 조회한 메뉴 정보(RAG)와 대화 기록을 바탕으로 동적 프롬프트를 생성
      - Gemini의 응답을 분석하여, 일반 대화와 주문을 위한 JSON(`action: "PLACE_ORDER"`)을 구분하여 처리하는 분기 로직을 구현

  - **외부 서비스 연동 구현 (Feign Client)**
      - 외부 API 및 내부 MSA 서비스와 통신하기 위한 `Feign Client` 인터페이스 3종을 구현
          - `GeminiClient`: 외부 Gemini API 호출 (API 키 인증을 위한 `GeminiClientConfig` 포함)
          - `MenuServiceClient`: 메뉴 정보 조회를 위해 `menu-service` 호출
          - `OrderServiceClient`: 주문 생성을 위해 `order-service` 호출

  - **API 엔드포인트 및 라우팅 변경**
      - `ChatController`의 기본 경로를 `/api/chatbot`으로 변경하고, API Gateway에 `/api/chatbot/**` 경로에 대한 라우팅 규칙을 추가
      - 다른 서비스 호출 시 권한 검증을 위해 필요한 헤더(`X-MANAGED-STORE-IDS`)를 Feign Client 요청에 포함하도록 수정

  - **도커라이제이션 및 MSA 환경 구성**
      - `chatbot-service`를 위한 `Dockerfile`을 생성
      - `docker-compose.yml`에 `chatbot-service`와 대화 기록 저장을 위한 전용 `mongodb-chatbot` 데이터베이스 컨테이너를 추가

  - **로깅 추가**
      - `@Slf4j`를 사용하여 프롬프트 생성, Gemini 응답, 외부 서비스 호출 등 주요 로직의 흐름을 추적할 수 있도록 상세한 로그를 추가

<br>

## 🧪 테스트

  - **단위 테스트**: `ChatServiceTest`
  - **슬라이스 테스트**: `ChatControllerTest`

<br>

## 🔗 관련 이슈

Closes #47 